### PR TITLE
Changing node0 ipv6 address from [::1] to ::1 as does not work from 6.3.0.GA - see bz#1064771

### DIFF
--- a/TXBridge/demo/demo-test/pom.xml
+++ b/TXBridge/demo/demo-test/pom.xml
@@ -234,7 +234,7 @@
             <activation><property><name>ipv6</name></property></activation>
             <properties>
                 <jvm.args.ip>-Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true</jvm.args.ip>
-                <node0>[::1]</node0>
+                <node0>::1</node0>
             </properties>
         </profile>
     </profiles>

--- a/TXBridge/wsat-jta-multi_hop/pom.xml
+++ b/TXBridge/wsat-jta-multi_hop/pom.xml
@@ -278,7 +278,7 @@
             <activation><property><name>ipv6</name></property></activation>
             <properties>
                 <jvm.args.ip>-Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true</jvm.args.ip>
-                <node0>[::1]</node0>
+                <node0>::1</node0>
             </properties>
         </profile>
 

--- a/TXBridge/wsat-jta-multi_service/pom.xml
+++ b/TXBridge/wsat-jta-multi_service/pom.xml
@@ -278,7 +278,7 @@
             <activation><property><name>ipv6</name></property></activation>
             <properties>
                 <jvm.args.ip>-Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true</jvm.args.ip>
-                <node0>[::1]</node0>
+                <node0>::1</node0>
             </properties>
         </profile>
 

--- a/XTS/demo/test/pom.xml
+++ b/XTS/demo/test/pom.xml
@@ -245,7 +245,7 @@
             <activation><property><name>ipv6</name></property></activation>
             <properties>
                 <jvm.args.ip>-Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true</jvm.args.ip>
-                <node0>[::1]</node0>
+                <node0>::1</node0>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
From time of 6.3.0.GA jboss Webservices are not able to start with address defined with square brackets (eg [::1]). In fact such specification of ip address is incorrect by spec. You should use just ::1.
The square brackets could be used just in url.

The result is that quickstarts does not work for EAP 6.3.0.GA when running on IPv6.