### PR TITLE
Changing node0 ipv6 address from [::1] to ::1 as does not work from 6.3.0.GA - see bz#1064771

### DIFF
--- a/XTS/raw-xts-api-demo/test/pom.xml
+++ b/XTS/raw-xts-api-demo/test/pom.xml
@@ -274,7 +274,7 @@
             <activation><property><name>ipv6</name></property></activation>
             <properties>
                 <jvm.args.ip>-Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true</jvm.args.ip>
-                <node0>[::1]</node0>
+                <node0>::1</node0>
             </properties>
         </profile>
     </profiles>

--- a/XTS/wsat-jta-multi_hop/pom.xml
+++ b/XTS/wsat-jta-multi_hop/pom.xml
@@ -236,5 +236,13 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>ipv6</id>
+            <activation><property><name>ipv6</name></property></activation>
+            <properties>
+                <jvm.args.ip>-Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true</jvm.args.ip>
+                <node0>::1</node0>
+            </properties>
+        </profile>
     </profiles>
 </project>

--- a/XTS/wsat-jta-multi_service/pom.xml
+++ b/XTS/wsat-jta-multi_service/pom.xml
@@ -236,5 +236,13 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>ipv6</id>
+            <activation><property><name>ipv6</name></property></activation>
+            <properties>
+                <jvm.args.ip>-Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true</jvm.args.ip>
+                <node0>::1</node0>
+            </properties>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Rework of jbosstm/quickstart/pull/130 for master as its difficult to test the QS on the 4.17 branch as they use AS 7.2 which is ancient!