### PR TITLE
Making Narayana version configurable

### DIFF
--- a/ArjunaCore/txoj/pom.xml
+++ b/ArjunaCore/txoj/pom.xml
@@ -23,6 +23,9 @@
   <packaging>jar</packaging>
   <name>TXOJ example</name>
   <description>TXOJ example</description>
+  <properties>
+    <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
+  </properties>
   <build>
     <plugins>
       <!-- This plugin allows our example to be executed by maven -->
@@ -52,7 +55,7 @@
     <dependency>
       <groupId>org.jboss.narayana.arjunacore</groupId>
       <artifactId>arjunacore</artifactId>
-      <version>5.3.3.Final-SNAPSHOT</version>
+      <version>${version.narayana}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/ArjunaJTA/jee_transactional_app/pom.xml
+++ b/ArjunaJTA/jee_transactional_app/pom.xml
@@ -35,6 +35,7 @@
             to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
             maven repository. -->
         <!-- <version.org.jboss.bom>1.0.0.Final-redhat-1</version.org.jboss.bom>> -->
+        <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
         <!-- other plugin versions -->
         <version.compiler.plugin>2.3.1</version.compiler.plugin>
         <version.surefire.plugin>2.19.1</version.surefire.plugin>
@@ -182,7 +183,7 @@
         <dependency>
             <groupId>org.jboss.narayana.jta</groupId>
             <artifactId>narayana-jta</artifactId>
-            <version>5.3.3.Final-SNAPSHOT</version>
+            <version>${version.narayana}</version>
             <scope>provided</scope>
         </dependency>
         <!-- Import the injection annotations -->

--- a/ArjunaJTA/maven/pom.xml
+++ b/ArjunaJTA/maven/pom.xml
@@ -19,6 +19,9 @@
     <packaging>jar</packaging>
     <name>basic maven example</name>
     <description>basic maven example</description>
+    <properties>
+      <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
+    </properties>
     <repositories>
         <repository>
             <id>jboss-public-repository-group</id>
@@ -97,7 +100,7 @@ read this as the JBoss stack of the Java EE 6 Web Profile APIs) -->
         <dependency>
             <groupId>org.jboss.narayana.jta</groupId>
             <artifactId>narayana-jta</artifactId>
-            <version>5.3.3.Final-SNAPSHOT</version>
+            <version>${version.narayana}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/ArjunaJTA/pom.xml
+++ b/ArjunaJTA/pom.xml
@@ -22,6 +22,7 @@
   </repositories>
   <properties>
     <version.surefire.plugin>2.19.1</version.surefire.plugin>
+    <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
   </properties>
   <build>
     <pluginManagement>
@@ -103,7 +104,7 @@
     <dependency>
       <groupId>org.jboss.narayana.jta</groupId>
       <artifactId>narayana-jta</artifactId>
-      <version>5.3.3.Final-SNAPSHOT</version>
+      <version>${version.narayana}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/ArjunaJTS/jts/pom.xml
+++ b/ArjunaJTS/jts/pom.xml
@@ -53,7 +53,7 @@
       <dependency>
         <groupId>org.jboss.narayana.quickstarts</groupId>
         <artifactId>jboss-as-jts-application-component-2</artifactId>
-        <version>5.3.3.Final-SNAPSHOT</version>
+        <version>${project.version}</version>
         <classifier>client</classifier>
       </dependency>
     </dependencies>

--- a/ArjunaJTS/pom.xml
+++ b/ArjunaJTS/pom.xml
@@ -22,6 +22,7 @@
   </repositories>
   <properties>
     <version.surefire.plugin>2.19.1</version.surefire.plugin>
+    <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
   </properties>
   <build>
     <pluginManagement>
@@ -95,7 +96,7 @@
     <dependency>
       <groupId>org.jboss.narayana.jts</groupId>
       <artifactId>narayana-jts-jacorb</artifactId>
-      <version>5.3.3.Final-SNAPSHOT</version>
+      <version>${version.narayana}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/ArjunaJTS/standalone/pom.xml
+++ b/ArjunaJTS/standalone/pom.xml
@@ -34,6 +34,10 @@
       </license>
     </licenses>
 
+    <properties>
+      <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
+    </properties>
+
     <repositories>
       <repository>
         <id>jbossThirdParty</id>
@@ -89,7 +93,7 @@
     <dependency>
       <groupId>org.jboss.narayana.jta</groupId>
       <artifactId>narayana-jta</artifactId>
-      <version>5.3.3.Final-SNAPSHOT</version>
+      <version>${version.narayana}</version>
     </dependency>
     <dependency>
       <groupId>org.jboss.logging</groupId>
@@ -106,7 +110,7 @@
     <dependency>
       <groupId>org.jboss.narayana.jts</groupId>
       <artifactId>narayana-jts-jacorb</artifactId>
-      <version>5.3.3.Final-SNAPSHOT</version>
+      <version>${version.narayana}</version>
     </dependency>
     <dependency>
       <groupId>org.jacorb</groupId>
@@ -118,7 +122,7 @@
     <dependency>
       <groupId>org.jboss.narayana.jts</groupId>
       <artifactId>narayana-jts-idlj</artifactId>
-      <version>5.3.3.Final-SNAPSHOT</version>
+      <version>${version.narayana}</version>
     </dependency>
   </dependencies>
 

--- a/ArjunaJTS/trailmap/pom.xml
+++ b/ArjunaJTS/trailmap/pom.xml
@@ -19,6 +19,9 @@
     <name>${project.artifactId}</name>
     <description>${project.artifactId}</description>
     <packaging>jar</packaging>
+    <properties>
+        <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
+    </properties>
     <repositories>
         <repository>
             <id>jboss-public-repository-group</id>
@@ -36,7 +39,7 @@
         <dependency>
             <groupId>org.jboss.narayana.jts</groupId>
             <artifactId>narayana-jts-jacorb</artifactId>
-            <version>5.3.3.Final-SNAPSHOT</version>
+            <version>${version.narayana}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.transaction</groupId>

--- a/STM/jta/pom.xml
+++ b/STM/jta/pom.xml
@@ -18,6 +18,9 @@
 	<artifactId>stm-jta</artifactId>
 	<version>5.3.3.Final-SNAPSHOT</version>
 	<packaging>jar</packaging>
+        <properties>
+                <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
+        </properties>
 	<repositories>
 		<repository>
 			<id>jboss-public-repository-group</id>
@@ -90,12 +93,12 @@
 		<dependency>
 			<groupId>org.jboss.narayana.jta</groupId>
 			<artifactId>narayana-jta</artifactId>
-			<version>5.3.3.Final-SNAPSHOT</version>
+                        <version>${version.narayana}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.narayana.stm</groupId>
 			<artifactId>stm</artifactId>
-			<version>5.3.3.Final-SNAPSHOT</version>
+                        <version>${version.narayana}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.logging</groupId>

--- a/STM/optimistic/pom.xml
+++ b/STM/optimistic/pom.xml
@@ -18,6 +18,9 @@
 	<artifactId>optimistic</artifactId>
 	<version>5.3.3.Final-SNAPSHOT</version>
 	<packaging>jar</packaging>
+        <properties>
+                <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
+        </properties>
 	<repositories>
 		<repository>
 			<id>jboss-public-repository-group</id>
@@ -62,7 +65,7 @@
 		<dependency>
 			<groupId>org.jboss.narayana.stm</groupId>
 			<artifactId>stm</artifactId>
-			<version>5.3.3.Final-SNAPSHOT</version>
+                        <version>${version.narayana}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.logging</groupId>

--- a/STM/pessimistic/pom.xml
+++ b/STM/pessimistic/pom.xml
@@ -18,6 +18,9 @@
 	<artifactId>pessimistic</artifactId>
 	<version>5.3.3.Final-SNAPSHOT</version>
 	<packaging>jar</packaging>
+        <properties>
+                <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
+        </properties>
 	<repositories>
 		<repository>
 			<id>jboss-public-repository-group</id>
@@ -61,7 +64,7 @@
 		<dependency>
 			<groupId>org.jboss.narayana.stm</groupId>
 			<artifactId>stm</artifactId>
-			<version>5.3.3.Final-SNAPSHOT</version>
+                        <version>${version.narayana}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.logging</groupId>

--- a/XTS/raw-xts-api-demo/core/pom.xml
+++ b/XTS/raw-xts-api-demo/core/pom.xml
@@ -13,6 +13,10 @@
     <artifactId>xts-demo-core</artifactId>
     <packaging>jar</packaging>
 
+    <properties>
+      <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
+    </properties>
+
     <repositories>
       <repository>
         <id>jboss-public-repository-group</id>
@@ -30,13 +34,13 @@
         <dependency>
             <groupId>org.jboss.narayana.arjunacore</groupId>
             <artifactId>arjunacore</artifactId>
-            <version>5.3.3.Final-SNAPSHOT</version>
+            <version>${version.narayana}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.narayana.xts</groupId>
             <artifactId>jbossxts</artifactId>
-            <version>5.3.3.Final-SNAPSHOT</version>
+            <version>${version.narayana}</version>
             <classifier>api</classifier>
             <scope>provided</scope>
         </dependency>

--- a/blacktie/integration1/ejb/ear/pom.xml
+++ b/blacktie/integration1/ejb/ear/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>org.jboss.narayana.blacktie.quickstarts</groupId>
             <artifactId>blacktie-quickstarts-integration1-ejb</artifactId>
-            <version>5.3.3.Final-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/blacktie/integration1/xatmi_adapter/ear/pom.xml
+++ b/blacktie/integration1/xatmi_adapter/ear/pom.xml
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>org.jboss.narayana.blacktie.quickstarts</groupId>
             <artifactId>blacktie-quickstarts-integration1-xatmi_adapter</artifactId>
-            <version>5.3.3.Final-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/blacktie/integration1/xatmi_adapter/pom.xml
+++ b/blacktie/integration1/xatmi_adapter/pom.xml
@@ -64,6 +64,9 @@
             <url>http://www.gnu.org/licenses/lgpl-2.1.html</url>
         </license>
     </licenses>
+    <properties>
+        <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
+    </properties>
     <repositories>
         <repository>
             <id>jboss-public-repository-group</id>
@@ -121,7 +124,7 @@
         <dependency>
             <groupId>org.jboss.narayana.blacktie.quickstarts</groupId>
             <artifactId>blacktie-quickstarts-integration1-ejb</artifactId>
-            <version>5.3.3.Final-SNAPSHOT</version>
+            <version>${project.version}</version>
             <classifier>client</classifier>
         </dependency>
         <dependency>
@@ -139,7 +142,7 @@
         <dependency>
             <groupId>org.jboss.narayana.blacktie</groupId>
             <artifactId>blacktie-jatmibroker-xatmi</artifactId>
-            <version>5.3.3.Final-SNAPSHOT</version>
+            <version>${version.narayana}</version>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>

--- a/blacktie/jatmibroker-xatmi/mdb-xatmi-service/ear/pom.xml
+++ b/blacktie/jatmibroker-xatmi/mdb-xatmi-service/ear/pom.xml
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>org.jboss.narayana.blacktie.quickstarts</groupId>
             <artifactId>blacktie-quickstarts-mdb-xatmi-service</artifactId>
-            <version>5.3.3.Final-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/blacktie/jatmibroker-xatmi/mdb-xatmi-service/pom.xml
+++ b/blacktie/jatmibroker-xatmi/mdb-xatmi-service/pom.xml
@@ -20,6 +20,9 @@
 	<packaging>jar</packaging>
 	<description>A BlackTie component</description>
 	<name>Blacktie XATMI MDB Quickstart</name>
+        <properties>
+            <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
+        </properties>
 	<repositories>
 		<repository>
 			<id>jboss-public-repository-group</id>
@@ -69,7 +72,7 @@
 		<dependency>
 			<groupId>org.jboss.narayana.blacktie</groupId>
 			<artifactId>blacktie-jatmibroker-xatmi</artifactId>
-			<version>5.3.3.Final-SNAPSHOT</version>
+                        <version>${version.narayana}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.spec.javax.jms</groupId>

--- a/compensating-transactions/mongodb-simple/pom.xml
+++ b/compensating-transactions/mongodb-simple/pom.xml
@@ -31,7 +31,7 @@
         <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered
   resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <narayana.version>5.3.3.Final-SNAPSHOT</narayana.version>
+        <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
         <version.org.wildfly.arquillian>1.0.1.Final</version.org.wildfly.arquillian>
         <ipv6.server.jvm.args>-Djboss.bind.address=[::1] -Djboss.bind.address.management=[::1] -Djboss.bind.address.unsecure=[::1] -Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true</ipv6.server.jvm.args>
         <jvm.args.memory>-Xms64m -Xmx1024m -XX:MaxPermSize=512m</jvm.args.memory>
@@ -77,7 +77,7 @@
             <groupId>org.jboss.narayana.xts</groupId>
             <artifactId>jbossxts</artifactId>
             <classifier>api</classifier>
-            <version>${narayana.version}</version>
+            <version>${version.narayana}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>org.jboss.narayana.xts</groupId>
             <artifactId>jbossxts</artifactId>
-            <version>${narayana.version}</version>
+            <version>${version.narayana}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>org.jboss.narayana.jts</groupId>
             <artifactId>narayana-jts-jacorb</artifactId>
-            <version>${narayana.version}</version>
+            <version>${version.narayana}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>org.jboss.narayana.compensations</groupId>
             <artifactId>compensations</artifactId>
-            <version>${narayana.version}</version>
+            <version>${version.narayana}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/compensating-transactions/non-transactional_resource/pom.xml
+++ b/compensating-transactions/non-transactional_resource/pom.xml
@@ -30,7 +30,7 @@
         <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered
   resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <narayana.version>5.3.3.Final-SNAPSHOT</narayana.version>
+        <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
         <version.org.wildfly.arquillian>1.0.1.Final</version.org.wildfly.arquillian>
         <ipv6.server.jvm.args>-Djboss.bind.address=[::1] -Djboss.bind.address.management=[::1] -Djboss.bind.address.unsecure=[::1] -Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true</ipv6.server.jvm.args>
         <jvm.args.memory>-Xms64m -Xmx1024m -XX:MaxPermSize=512m</jvm.args.memory>
@@ -67,7 +67,7 @@
             <groupId>org.jboss.narayana.xts</groupId>
             <artifactId>jbossxts</artifactId>
             <classifier>api</classifier>
-            <version>${narayana.version}</version>
+            <version>${version.narayana}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>org.jboss.narayana.compensations</groupId>
             <artifactId>compensations</artifactId>
-            <version>${narayana.version}</version>
+            <version>${version.narayana}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/compensating-transactions/travel-agent/pom.xml
+++ b/compensating-transactions/travel-agent/pom.xml
@@ -31,7 +31,7 @@
         <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered
   resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <narayana.version>5.3.3.Final-SNAPSHOT</narayana.version>
+        <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
         <version.org.wildfly.arquillian>1.0.1.Final</version.org.wildfly.arquillian>
         <ipv6.server.jvm.args>-Djboss.bind.address=[::1] -Djboss.bind.address.management=[::1] -Djboss.bind.address.unsecure=[::1] -Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true</ipv6.server.jvm.args>
         <jvm.args.memory>-Xms64m -Xmx1024m -XX:MaxPermSize=512m</jvm.args.memory>
@@ -68,7 +68,7 @@
             <groupId>org.jboss.narayana.xts</groupId>
             <artifactId>jbossxts</artifactId>
             <classifier>api</classifier>
-            <version>${narayana.version}</version>
+            <version>${version.narayana}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.jboss.narayana.compensations</groupId>
             <artifactId>compensations</artifactId>
-            <version>${narayana.version}</version>
+            <version>${version.narayana}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>org.jboss.narayana.jta</groupId>
             <artifactId>narayana-jta</artifactId>
-            <version>${narayana.version}</version>
+            <version>${version.narayana}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/jca-and-hibernate/pom.xml
+++ b/jca-and-hibernate/pom.xml
@@ -43,7 +43,7 @@
         <version.org.hibernate>4.2.7.SP1</version.org.hibernate>
         <version.org.hibernate.hibernate-validator>5.0.1.Final</version.org.hibernate.hibernate-validator>
         <version.org.jboss.jboss-common-core>2.2.17.GA</version.org.jboss.jboss-common-core>
-        <version.org.jboss.narayana>${project.version}</version.org.jboss.narayana>
+        <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
         <version.org.jboss.logging.jboss-logging>3.1.2.GA</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-spi>2.2.0.CR1</version.org.jboss.logging.jboss-logging-spi>
         <version.org.jboss.logmanager-jboss-logmanager>1.4.0.Final</version.org.jboss.logmanager-jboss-logmanager>
@@ -346,12 +346,12 @@
         <dependency>
             <groupId>org.jboss.narayana.jta</groupId>
             <artifactId>narayana-jta</artifactId>
-            <version>${version.org.jboss.narayana}</version>
+            <version>${version.narayana}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.narayana.jts</groupId>
             <artifactId>narayana-jts-integration</artifactId>
-            <version>${version.org.jboss.narayana}</version>
+            <version>${version.narayana}</version>
         </dependency>
 
         <!-- Other dependencies -->

--- a/jca-and-tomcat/pom.xml
+++ b/jca-and-tomcat/pom.xml
@@ -44,7 +44,7 @@
         <version.org.hibernate>5.0.1.Final</version.org.hibernate>
         <version.org.javassist>3.16.1-GA</version.org.javassist>
         <version.org.jboss.jboss-common-core>2.2.17.GA</version.org.jboss.jboss-common-core>
-        <version.org.jboss.narayana>${project.version}</version.org.jboss.narayana>
+        <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
         <version.org.jboss.logging.jboss-logging>3.1.2.GA</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-spi>2.2.0.CR1</version.org.jboss.logging.jboss-logging-spi>
         <version.org.jboss.logmanager-jboss-logmanager>1.4.0.Final</version.org.jboss.logmanager-jboss-logmanager>
@@ -382,7 +382,7 @@
         <dependency>
             <groupId>org.jboss.narayana.jta</groupId>
             <artifactId>narayana-jta</artifactId>
-            <version>${version.org.jboss.narayana}</version>
+            <version>${version.narayana}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.jboss.spec.javax.servlet</groupId>
@@ -393,7 +393,7 @@
         <dependency>
             <groupId>org.jboss.narayana.jts</groupId>
             <artifactId>narayana-jts-integration</artifactId>
-            <version>${version.org.jboss.narayana}</version>
+            <version>${version.narayana}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.jboss.spec.javax.servlet</groupId>

--- a/jta-and-hibernate/pom.xml
+++ b/jta-and-hibernate/pom.xml
@@ -39,7 +39,7 @@
         <maven.compiler.source>1.7</maven.compiler.source>
         <version.maven-compiler-plugin>3.1</version.maven-compiler-plugin>
         <version.maven-surefire-plugin>2.19.1</version.maven-surefire-plugin>
-        <version.org.jboss.narayana>${project.version}</version.org.jboss.narayana>
+        <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
         <version.org.jboss.spec.javax.transaction>1.0.0.Final</version.org.jboss.spec.javax.transaction>
         <version.org.jboss.naming>5.0.3.GA</version.org.jboss.naming>
         <version.org.jboss.logging.jboss-logging>3.1.2.GA</version.org.jboss.logging.jboss-logging>
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.jboss.narayana.jta</groupId>
             <artifactId>narayana-jta</artifactId>
-            <version>${version.org.jboss.narayana}</version>
+            <version>${version.narayana}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.jboss.logmanager</groupId>

--- a/jts-docker/pom.xml
+++ b/jts-docker/pom.xml
@@ -19,6 +19,7 @@
         <version.jacorb>2.3.1jboss.patch01-brew</version.jacorb>
         <version.org.slf4j>1.7.2.jbossorg-1</version.org.slf4j>
         <version.junit>4.12</version.junit>
+        <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
     </properties>
 
     <repositories>
@@ -40,7 +41,7 @@
         <dependency>
             <groupId>org.jboss.narayana.jts</groupId>
             <artifactId>narayana-jts-jacorb</artifactId>
-            <version>${project.version}</version>
+            <version>${version.narayana}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/karaf/osgi-jta/pom.xml
+++ b/karaf/osgi-jta/pom.xml
@@ -37,7 +37,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.org.jboss.spec.javax.transaction>1.0.0.Final</version.org.jboss.spec.javax.transaction>
-        <version.org.jboss.narayana>5.2.9.Final</version.org.jboss.narayana>
+        <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
         <version.org.jboss.jboss-transaction-spi>7.3.0.Final</version.org.jboss.jboss-transaction-spi>
         <osgi.version>6.0.0</osgi.version>
         <karaf.version>4.1.0-SNAPSHOT</karaf.version>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.jboss.narayana.osgi</groupId>
             <artifactId>narayana-osgi-jta</artifactId>
-            <version>${version.org.jboss.narayana}</version>
+            <version>${version.narayana}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/rts/at/demo/pom.xml
+++ b/rts/at/demo/pom.xml
@@ -14,6 +14,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.build.timestamp.format>yyyyMMdd'T'HHmmss</maven.build.timestamp.format>
+    <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
   </properties>
 
   <repositories>
@@ -63,7 +64,7 @@
     <dependency>
       <groupId>org.jboss.narayana.rts</groupId>
       <artifactId>restat-api</artifactId>
-      <version>5.3.3.Final-SNAPSHOT</version>
+      <version>${version.narayana}</version>
     </dependency>
     <!-- Jersey container for running participant services -->
     <dependency>

--- a/rts/at/jta-service/jms/pom.xml
+++ b/rts/at/jta-service/jms/pom.xml
@@ -45,6 +45,7 @@
       <jvm.args.debug></jvm.args.debug>
       <jvm.args.other>-server</jvm.args.other>
       <version.surefire.plugin>2.19.1</version.surefire.plugin>
+      <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
     </properties>
 
     <repositories>
@@ -91,7 +92,7 @@
         <dependency>
             <groupId>org.jboss.narayana.rts</groupId>
             <artifactId>restat-util</artifactId>
-            <version>${project.version}</version>
+            <version>${version.narayana}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/rts/at/jta-service/jpa/pom.xml
+++ b/rts/at/jta-service/jpa/pom.xml
@@ -37,6 +37,10 @@
 
     <modelVersion>4.0.0</modelVersion>
 
+    <properties>
+        <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
+    </properties>
+
     <repositories>
         <repository>
             <id>jboss-public-repository-group</id>
@@ -69,7 +73,7 @@
         <dependency>
             <groupId>org.jboss.narayana.rts</groupId>
             <artifactId>restat-util</artifactId>
-            <version>${project.version}</version>
+            <version>${version.narayana}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/rts/at/recovery/recovery1/pom.xml
+++ b/rts/at/recovery/recovery1/pom.xml
@@ -10,6 +10,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.build.timestamp.format>yyyyMMdd'T'HHmmss</maven.build.timestamp.format>
+        <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
     </properties>
 
     <repositories>
@@ -38,7 +39,7 @@
         <dependency>
             <groupId>org.jboss.narayana.rts</groupId>
             <artifactId>restat-util</artifactId>
-            <version>5.3.3.Final-SNAPSHOT</version>
+            <version>${version.narayana}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/rts/at/recovery/recovery2/pom.xml
+++ b/rts/at/recovery/recovery2/pom.xml
@@ -10,6 +10,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.build.timestamp.format>yyyyMMdd'T'HHmmss</maven.build.timestamp.format>
+        <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
     </properties>
 
     <build>
@@ -52,19 +53,19 @@
         <dependency>
             <groupId>org.jboss.narayana.rts</groupId>
             <artifactId>restat-integration</artifactId>
-            <version>5.3.3.Final-SNAPSHOT</version>
+            <version>${version.narayana}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.narayana.jts</groupId>
             <artifactId>narayana-jts-jacorb</artifactId>
-            <version>5.3.3.Final-SNAPSHOT</version>
+            <version>${version.narayana}</version>
         </dependency>
 
         <!-- RESTAT utils -->
         <dependency>
             <groupId>org.jboss.narayana.rts</groupId>
             <artifactId>restat-util</artifactId>
-            <version>5.3.3.Final-SNAPSHOT</version>
+            <version>${version.narayana}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/rts/at/service/service1/pom.xml
+++ b/rts/at/service/service1/pom.xml
@@ -10,6 +10,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.build.timestamp.format>yyyyMMdd'T'HHmmss</maven.build.timestamp.format>
+        <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
     </properties>
 
     <repositories>
@@ -45,7 +46,7 @@
         <dependency>
             <groupId>org.jboss.narayana.rts</groupId>
             <artifactId>restat-util</artifactId>
-            <version>5.3.3.Final-SNAPSHOT</version>
+            <version>${version.narayana}</version>
         </dependency>
         <!-- Jersey container for running participant services -->
         <dependency>

--- a/rts/at/service/service1b/pom.xml
+++ b/rts/at/service/service1b/pom.xml
@@ -51,6 +51,8 @@
             maven repository. -->
         <!-- <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-2</version.jboss.spec.javaee.6.0> -->
 
+        <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
+
         <!-- other plugin versions -->
         <version.compiler.plugin>3.1</version.compiler.plugin>
         <version.war.plugin>2.1.1</version.war.plugin>
@@ -101,7 +103,7 @@
         <dependency>
             <groupId>org.jboss.narayana.rts</groupId>
             <artifactId>restat-util</artifactId>
-            <version>5.3.3.Final-SNAPSHOT</version>
+            <version>${version.narayana}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/rts/at/service/service2/pom.xml
+++ b/rts/at/service/service2/pom.xml
@@ -10,6 +10,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.build.timestamp.format>yyyyMMdd'T'HHmmss</maven.build.timestamp.format>
+        <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
     </properties>
 
     <repositories>
@@ -73,12 +74,12 @@
         <dependency>
             <groupId>org.jboss.narayana.rts</groupId>
             <artifactId>restat-integration</artifactId>
-            <version>5.3.3.Final-SNAPSHOT</version>
+            <version>${version.narayana}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.narayana.jts</groupId>
             <artifactId>narayana-jts-jacorb</artifactId>
-            <version>5.3.3.Final-SNAPSHOT</version>
+            <version>${version.narayana}</version>
         </dependency>
         <!-- JBoss logging -->
         <dependency>
@@ -90,7 +91,7 @@
         <dependency>
             <groupId>org.jboss.narayana.rts</groupId>
             <artifactId>restat-util</artifactId>
-            <version>5.3.3.Final-SNAPSHOT</version>
+            <version>${version.narayana}</version>
         </dependency>
         <!-- Jersey container for running participant services -->
         <dependency>

--- a/rts/at/service/service2b/pom.xml
+++ b/rts/at/service/service2b/pom.xml
@@ -73,6 +73,8 @@
             maven repository. -->
         <!-- <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-2</version.jboss.spec.javaee.6.0> -->
 
+        <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
+
         <!-- other plugin versions -->
         <version.compiler.plugin>3.1</version.compiler.plugin>
         <version.war.plugin>2.1.1</version.war.plugin>
@@ -109,20 +111,20 @@
         <dependency>
             <groupId>org.jboss.narayana.rts</groupId>
             <artifactId>restat-integration</artifactId>
-            <version>5.3.3.Final-SNAPSHOT</version>
+            <version>${version.narayana}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.narayana.jts</groupId>
             <artifactId>narayana-jts-jacorb</artifactId>
-            <version>5.3.3.Final-SNAPSHOT</version>
+            <version>${version.narayana}</version>
         </dependency>
 
         <!-- REST-AT helper -->
         <dependency>
             <groupId>org.jboss.narayana.rts</groupId>
             <artifactId>restat-util</artifactId>
-            <version>5.3.3.Final-SNAPSHOT</version>
+            <version>${version.narayana}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -196,7 +198,7 @@
                 <dependency>
                     <groupId>org.jboss.narayana.rts</groupId>
                     <artifactId>restat-util</artifactId>
-                    <version>5.3.3.Final-SNAPSHOT</version>
+                    <version>${version.narayana}</version>
                 </dependency>
             </dependencies>
             <build>

--- a/rts/at/simple/pom.xml
+++ b/rts/at/simple/pom.xml
@@ -26,6 +26,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.build.timestamp.format>yyyyMMdd'T'HHmmss</maven.build.timestamp.format>
+    <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
   </properties>
 
     <repositories>
@@ -71,7 +72,7 @@
     <dependency>
       <groupId>org.jboss.narayana.rts</groupId>
       <artifactId>restat-util</artifactId>
-      <version>5.3.3.Final-SNAPSHOT</version>
+      <version>${version.narayana}</version>
     </dependency>
     <!-- JBoss logging -->
     <dependency>

--- a/rts/at/undertow/pom.xml
+++ b/rts/at/undertow/pom.xml
@@ -26,7 +26,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <rts.version>${project.version}</rts.version>
+        <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
         <version.org.jboss.logging.jboss-logging>3.2.1.Final</version.org.jboss.logging.jboss-logging>
         <undertow.io.version>1.3.0.Beta6</undertow.io.version>
         <resteasy.version>3.0.11.Final</resteasy.version>
@@ -50,17 +50,17 @@
         <dependency>
             <groupId>org.jboss.narayana.rts</groupId>
             <artifactId>restat-util</artifactId>
-            <version>${rts.version}</version>
+            <version>${version.narayana}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.narayana.rts</groupId>
             <artifactId>restat-api</artifactId>
-            <version>${rts.version}</version>
+            <version>${version.narayana}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.narayana.arjunacore</groupId>
             <artifactId>arjunacore</artifactId>
-            <version>${project.version}</version>
+            <version>${version.narayana}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/spring/jta/pom.xml
+++ b/spring/jta/pom.xml
@@ -43,7 +43,7 @@
         <version.maven-compiler-plugin>3.1</version.maven-compiler-plugin>
         <version.maven-surefire-plugin>2.9</version.maven-surefire-plugin>
         <version.org.springframwork>4.2.0.RELEASE</version.org.springframwork>
-        <version.org.jboss.narayana>${project.version}</version.org.jboss.narayana>
+        <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
         <version.org.jboss.logging.jboss-logging>3.1.2.GA</version.org.jboss.logging.jboss-logging>
         <version.log4j>1.2.16</version.log4j>
         <version.org.jboss.spec.javax.transaction>1.0.1.Final</version.org.jboss.spec.javax.transaction>
@@ -93,17 +93,17 @@
         <dependency>
             <groupId>org.jboss.narayana.jta</groupId>
             <artifactId>jta</artifactId>
-            <version>${version.org.jboss.narayana}</version>
+            <version>${version.narayana}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.narayana.jta</groupId>
             <artifactId>jdbc</artifactId>
-            <version>${version.org.jboss.narayana}</version>
+            <version>${version.narayana}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.narayana.jts</groupId>
             <artifactId>narayana-jts-integration</artifactId>
-            <version>${version.org.jboss.narayana}</version>
+            <version>${version.narayana}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/wildfly/setCheckedActionFactoryExample/pom.xml
+++ b/wildfly/setCheckedActionFactoryExample/pom.xml
@@ -10,6 +10,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.target>1.6</maven.compiler.target>
 		<maven.compiler.source>1.6</maven.compiler.source>
+                <version.narayana>5.3.3.Final-SNAPSHOT</version.narayana>
 	</properties>
   <repositories>
     <repository>
@@ -28,7 +29,7 @@
 		<dependency>
 			<groupId>org.jboss.narayana.jta</groupId>
 			<artifactId>jta</artifactId>
-			<version>5.3.3.Final-SNAPSHOT</version>
+			<version>${version.narayana}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Changing pom.xml files to not have hardcoded version for Narayana plus
unifying the name of property that is used for setting the Narayana
dependency version to 'version.narayana'.