### PR TITLE
[JBTM-2726] Replace deprecated OutputCapture in Spring Boot quickstart test

### DIFF
--- a/spring/narayana-spring-boot/src/test/java/org/jboss/narayana/quickstart/spring/QuickstartApplicationTests.java
+++ b/spring/narayana-spring-boot/src/test/java/org/jboss/narayana/quickstart/spring/QuickstartApplicationTests.java
@@ -18,7 +18,7 @@ package org.jboss.narayana.quickstart.spring;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.springframework.boot.test.OutputCapture;
+import org.springframework.boot.test.rule.OutputCapture;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-2726