### PR TITLE
JBTM-2816 Quickstart can not find the mvn.bat after upgrade to maven 3.3.9

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -53,7 +53,7 @@ REM ********* Search for names in the subfolders *********
 REM ******************************************************
 
 :subLoop
-for %%j in (%SUBFOLDERS%) do call :testIfExists %%j\%1\bin\mvn.bat %2 %3 %4 %5 %6 %7
+for %%j in (%SUBFOLDERS%) do call :testIfExists %%j\%1\bin\mvn %2 %3 %4 %5 %6 %7
 
 goto :EOF
 


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-2816