### PR TITLE
JBTM-2874 GlassFish interop

### DIFF
--- a/ArjunaJTS/interop/README.md
+++ b/ArjunaJTS/interop/README.md
@@ -1,0 +1,49 @@
+OVERVIEW
+--------
+
+This example shows how to propagate a transaction context between the WildFly and GlassFish application
+servers. There is a single script to run the full example but you may find it more instructive to run
+the example in steps perhaps in separate command windows:
+
+USAGE
+-----
+
+./run.sh
+
+or to run each step at a time:
+
+1. step1.sh:
+  - builds GlassFish either from source (using svn) or via prebuilt binaries. The build from source also needs patching using the included patch file (see https://java.net/jira/browse/GLASSFISH-21532 for details);
+  - builds narayana using the latest version (controlled by the environment variable NARAYANA_CURRENT_VERSION)
+  - patches and builds the WildFly version downloaded during the narayana build. The patch disables the interceptor that blocks the importing of foreign transactions. When we have a JIRA to for the issue we will update this README.
+2. step2.sh: starts WildFly in JTS mode
+3. step3.sh: starts a GlassFish domain
+4. step4.sh: deploys the test EJB to both servers (for making transactional calls between them)
+5. step5.sh: Make an ejb call from GlassFish to WildFly (using the script in ejb_operations.sh)
+6. step6.sh: Make an ejb call from WildFly to GlassFish (using the script in ejb_operations.sh)
+7. step7.sh: Undeploy EJBs and shutdown GlassFish and WildFly
+
+EXPECTED OUTPUT
+---------------
+
+These steps generate too much output to show in full.
+
+The key output lines to verify that the GlassFish to WildFly transactional EJB call worked is to look for the line:
+
+> ===== JTS interop quickstart: step 5 (EJB call gf -> wf):
+
+followed soon after by a line that includes
+
+> Next: 8000
+
+The number printed will increment on each EJB call.
+
+The key output lines to verify that the WildFly to GlassFish transactional EJB call worked is to look for the line:
+> ===== JTS interop quickstart: step 6 (EJB call wf -> gf):
+
+followed soon after by
+
+> Next: 7000
+
+The number printed will increment on each EJB call.
+

--- a/ArjunaJTS/interop/glassfish/GLASSFISH-21532.diff
+++ b/ArjunaJTS/interop/glassfish/GLASSFISH-21532.diff
@@ -1,0 +1,25 @@
+Index: appserver/transaction/jts/src/main/java/com/sun/jts/CosTransactions/GlobalTID.java
+===================================================================
+--- appserver/transaction/jts/src/main/java/com/sun/jts/CosTransactions/GlobalTID.java	(revision 64262)
++++ appserver/transaction/jts/src/main/java/com/sun/jts/CosTransactions/GlobalTID.java	(working copy)
+@@ -310,13 +310,16 @@
+ 
+         // Add up the values in the XID.
+ 
+-        if( realTID.tid != null )
+-            for( int pos = 0; pos < realTID.tid.length; pos++ )
++        if( realTID.tid != null ) {
++            int gtid_len = realTID.tid.length - realTID.bqual_length;
++
++            for( int pos = 0; pos < gtid_len; pos++ )
+                 hashCode += realTID.tid[pos];
++        }
+ 
+-        // Add in the formatId and branch qualifier length.
++        // Add in the formatId but ignore the branch qualifier.
+ 
+-        hashCode += realTID.formatID + realTID.bqual_length;
++        hashCode += realTID.formatID;// + realTID.bqual_length;
+ 
+         // Multiply the result by the "magic hashing constant".
+ 

--- a/ArjunaJTS/interop/glassfish/configure-jts-transactions.cli
+++ b/ArjunaJTS/interop/glassfish/configure-jts-transactions.cli
@@ -1,0 +1,20 @@
+# Batch script to configure the WildFly server for JTS transactions
+
+# Start batching commands
+batch
+
+# Configure transactions for JTS
+/subsystem=iiop-openjdk/:write-attribute(name=transactions,value=full)
+/subsystem=transactions/:write-attribute(name=jts,value=true)
+/subsystem=transactions/:write-attribute(name=node-identifier,value=${jboss.tx.node.id})
+
+# makes some changes for interoperabilit with glassfish
+# override the transaction propagation slot id to the standard one - this is done in the run script
+#/system-property=com.arjuna.ats.jts.transactionServiceId:add(value=0)
+
+# Run the batch commands
+run-batch
+
+# Reload the server configuration
+:reload
+

--- a/ArjunaJTS/interop/glassfish/ejb_operations.sh
+++ b/ArjunaJTS/interop/glassfish/ejb_operations.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+source init.sh
+set +e
+
+export PATH=$GLASSFISH/bin:$PATH
+[ -d "$JBOSS_HOME"  ] || fatal "file not found: $JBOSS_HOME"
+[ -f "$GLASSFISH/bin/asadmin"  ] || fatal "asadmin not found"
+
+WF_DEPLOY_DIR=$JBOSS_HOME/standalone/deployments
+
+usage() {
+  echo -e "$1: Usage: $0 [-a <gf|gf2|wf>] [-f <archive>] [-t <gfgf|gfwf|wfgf >] [-t <haltbefore|haltafter>]" 1>&2;
+  echo -e "examples:"
+  echo -e "\t$0 -t wfgf # send a message from WildFly to GlassFish"
+  echo -e "\t$0 -t wfgf -t halt # send a message from WildFly to GlassFish and then halt GlassFish"
+  echo -e "\t$0 -a wf1 -f ${QS_DIR}/target/ejbtest.war # deploy an archive to wildfly"
+  echo -e "$0 -a gf1 -f recovery/target/dummy-resource-recovery.jar  # deploy an archive to WildFly"
+  exit 1;
+}
+
+http_get() {
+  res=$( curl --max-time 10 -qSfsw '\n%{http_code}' $1 ) # 2>/dev/null
+  exit_code=$?
+  http_code=$(echo "$res" | tail -n1) # the HTTP status code is the last line of the curl output
+
+  echo "http get for $1 curl status: $exit_code http status: $http_code res=$res"
+
+  if [ $exit_code = 0 ]; then
+    echo "http get for $1 curl ok"
+  else
+    fatal "curl error: $exit_code http status: $http_code for url $1"
+  fi
+
+  if [ $http_code = 200 ]; then
+    echo "http get for $1 status ok"
+  else
+    fatal "unexpected http status code: $http_code for url $1"
+  fi
+
+  # the last line is the body of the response:
+  echo "EJB test returned: $res" | head -n-1
+}
+
+itest() {
+  how=x
+  [ $# -gt 1 ] && how=$2
+
+  case $1 in
+  gfgf) http_get http://localhost:7080/ejbtest/rs/remote/3700/gf/$how ;;
+  gfwf) http_get http://localhost:7080/ejbtest/rs/remote/3528/wf/$how ;;
+  wfgf) http_get http://localhost:8080/ejbtest/rs/remote/3700/gf/$how ;;
+  wfwf) http_get http://localhost:8080/ejbtest/rs/remote/3728/wf/$how ;;
+  *)
+  esac
+
+  exit $?
+}
+
+while getopts "t:a:f:" o; do
+case "${o}" in
+  t) iargs+=("$OPTARG");;
+  a) a=${OPTARG};;
+  f) f=${OPTARG};;
+  *) usage;;
+esac
+done
+
+[ ${#iargs[@]} != 0 ] && itest ${iargs[*]}
+
+[ $f ] || usage "missing file"
+
+case $a in
+  gf)  asadmin --port 4848 deploy --force=true $f
+       asadmin --port 4948 deploy --force=true $f
+       ;;
+  wf)  cp $f $WF_DEPLOY_DIR
+       cp $f $WF2_DEPLOY_DIR
+       ;;
+  wf1) cp $f $WF_DEPLOY_DIR;; # WildFly uses ports 8080 3528
+  gf1) asadmin --port 4848 deploy --force=true $f;;
+
+  uwf1) rm $WF_DEPLOY_DIR/${f}.war;; # WildFly uses ports 8080 3528
+  ugf1) asadmin --port 4848 undeploy $f;;
+
+  gf2) asadmin --port 4948 deploy --force=true $f;;
+  wf2) cp $f $WF2_DEPLOY_DIR;; # GlassFish uses ports 9280 3628
+  *) usage "missing as"
+esac
+

--- a/ArjunaJTS/interop/glassfish/init.sh
+++ b/ArjunaJTS/interop/glassfish/init.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -ex
+
+function fatal {
+  echo "$1"; exit 1
+}
+
+[ $WORKSPACE ] || fatal "please set WORKSPACE to the quickstarts directory"
+[ $NARAYANA_CURRENT_VERSION ] || fatal "please set NARAYANA_CURRENT_VERSION"
+
+QS_DIR=${WORKSPACE}/ArjunaJTS/interop/glassfish
+JBOSS_SRC=${QS_DIR}/tmp/narayana/jboss-as
+if [ -f "${JBOSS_SRC}/pom.xml" ]; then
+  WILDFLY_MASTER_VERSION=`awk "/wildfly-parent/ {getline;print;}" ${JBOSS_SRC}/pom.xml | cut -d \< -f 2|cut -d \> -f 2`
+fi
+
+export JBOSS_HOME="$JBOSS_SRC/build/target/wildfly-$WILDFLY_MASTER_VERSION"
+
+if [ -d "/home/jenkins/glassfish4" ]; then
+  GLASSFISH=/home/jenkins/glassfish4
+elif [ -d "$QS_DIR/tmp/glassfish4/appserver/distributions/glassfish/target/stage/glassfish4" ]; then
+  GLASSFISH=$QS_DIR/tmp/glassfish4/appserver/distributions/glassfish/target/stage/glassfish4
+else
+  unset GLASSFISH
+fi

--- a/ArjunaJTS/interop/glassfish/interop.wildfly.diff
+++ b/ArjunaJTS/interop/glassfish/interop.wildfly.diff
@@ -1,0 +1,29 @@
+diff --git a/ejb3/src/main/java/org/jboss/as/ejb3/iiop/EjbIIOPTransactionInterceptor.java b/ejb3/src/main/java/org/jboss/as/ejb3/iiop/EjbIIOPTransactionInterceptor.java
+index 968679c..52a1e86 100644
+--- a/ejb3/src/main/java/org/jboss/as/ejb3/iiop/EjbIIOPTransactionInterceptor.java
++++ b/ejb3/src/main/java/org/jboss/as/ejb3/iiop/EjbIIOPTransactionInterceptor.java
+@@ -22,12 +22,10 @@
+ 
+ package org.jboss.as.ejb3.iiop;
+ 
+-import javax.ejb.TransactionAttributeType;
+ import javax.transaction.Transaction;
+ 
+ import org.jboss.as.ee.component.Component;
+ import org.jboss.as.ee.component.ComponentView;
+-import org.jboss.as.ejb3.logging.EjbLogger;
+ import org.jboss.as.ejb3.component.EJBComponent;
+ import org.jboss.as.ejb3.component.MethodIntf;
+ import org.jboss.invocation.ImmediateInterceptorFactory;
+@@ -62,11 +60,6 @@ public class EjbIIOPTransactionInterceptor implements Interceptor {
+                     methodIntf = MethodIntf.BEAN;
+                 }
+             }
+-
+-            final TransactionAttributeType attr = component.getTransactionAttributeType(methodIntf, invocation.getMethod());
+-            if (attr != TransactionAttributeType.NOT_SUPPORTED && attr != TransactionAttributeType.REQUIRES_NEW) {
+-                throw EjbLogger.ROOT_LOGGER.transactionPropagationNotSupported();
+-            }
+         }
+         return invocation.proceed();
+     }

--- a/ArjunaJTS/interop/glassfish/pom.xml
+++ b/ArjunaJTS/interop/glassfish/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+	JBoss, Home of Professional Open Source Copyright 2010, Red Hat
+	Middleware LLC, and others contributors as indicated by the @authors
+	tag. All rights reserved. See the copyright.txt in the distribution
+	for a full listing of individual contributors. This copyrighted
+	material is made available to anyone wishing to use, modify, copy, or
+	redistribute it subject to the terms and conditions of the GNU Lesser
+	General Public License, v. 2.1. This program is distributed in the
+	hope that it will be useful, but WITHOUT A WARRANTY; without even the
+	implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+	PURPOSE. See the GNU Lesser General Public License for more details.
+	You should have received a copy of the GNU Lesser General Public
+	License, v.2.1 along with this distribution; if not, write to the Free
+	Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+	02110-1301, USA.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jboss.narayana.quickstart.jts</groupId>
+    <artifactId>jts-interop-quickstart</artifactId>
+    <version>5.5.6.Final-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>glassfish-interop</artifactId>
+  <packaging>jar</packaging>
+  <name>JTS Interoperability Quickstart: GlassFish</name>
+  <description>Transactional EJB calls between GlassFish and WildFly</description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>exec-maven-plugin</artifactId>
+        <groupId>org.codehaus.mojo</groupId>
+        <executions>
+          <execution>
+            <id>Execute Run Scripts</id>
+            <phase>integration-test</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>${basedir}/run.sh</executable>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/ArjunaJTS/interop/glassfish/run.sh
+++ b/ArjunaJTS/interop/glassfish/run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -ex
+
+echo "===== JTS interop quickstart: step 1 (compile gf and wf):"; ./step1.sh; sleep 3
+echo "===== JTS interop quickstart: step 2 (start WildFly):"; ./step2.sh; sleep 10
+echo "===== JTS interop quickstart: step 3 (start GlassFish):"; ./step3.sh; sleep 10
+trap ./step7.sh EXIT
+echo "===== JTS interop quickstart: step 4 (deploy EJBs):"; ./step4.sh; sleep 10
+echo "===== JTS interop quickstart: step 5 (EJB call gf -> wf):"; ./step5.sh; sleep 4
+echo "===== JTS interop quickstart: step 6 (EJB call wf -> gf):"; ./step6.sh; sleep 4
+

--- a/ArjunaJTS/interop/glassfish/step1.sh
+++ b/ArjunaJTS/interop/glassfish/step1.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+source init.sh
+
+set -e
+
+# build the latest version of narayana 
+function build_narayana {
+  WS=$WORKSPACE
+
+  WORKSPACE="${QS_DIR}/tmp/narayana"
+
+  rm -rf $WORKSPACE
+
+  if [ ! -d "$WORKSPACE" ]; then
+    git clone https://github.com/jbosstm/narayana.git $WORKSPACE
+    [ $? = 0 ] || fatal "Git clone narayana repo failed"
+  fi
+
+  cd $WORKSPACE 
+
+  PROFILE=NONE AS_BUILD=1 NARAYANA_BUILD=1 NARAYANA_TESTS=0 BLACKTIE=0 XTS_AS_TESTS=0 XTS_TESTS=0 TXF_TESTS=0 txbridge=0 RTS_AS_TESTS=0 RTS_TESTS=0 JTA_CDI_TESTS=0 QA_TESTS=0 SUN_ORB=0 JAC_ORB=0 JTA_AS_TESTS=0 OSGI_TESTS=0 ./scripts/hudson/narayana.sh -B -DskipTests
+  [ $? = 0 ] || fatal "Build narayana failed"
+
+  WORKSPACE=$WS
+}
+
+# patch and build WildFly 
+function build_wf {
+  WS=$WORKSPACE
+
+  WORKSPACE="$QS_DIR/tmp/narayana/jboss-as"
+
+  cd $WORKSPACE
+
+  git apply $QS_DIR/interop.wildfly.diff
+
+  ./build.sh clean install -B -DskipTests -Drelease=true -Dlicense.skipDownloadLicenses=true -Dversion.org.jboss.narayana=$NARAYANA_CURRENT_VERSION
+  WORKSPACE=$WS
+}
+
+# patch and build glassfish 
+function build_gf {
+  GLASSFISH=${GLASSFISH:=xyz}
+  if [ ! -d $GLASSFISH ]; then
+    echo looking for glassfish
+    # if we are not running using jenkins CI then get the GlassFish sources via svn
+    if [ -z ${JENKINS_HOST+x} ]; then
+      echo getting glassfish via svn
+      svn checkout https://svn.java.net/svn/glassfish~svn/trunk/main $QS_DIR/tmp/glassfish4
+      cd $QS_DIR/tmp/glassfish4
+      patch -p0 -i $QS_DIR/GLASSFISH-21532.diff  
+      mvn install -B -Dmaven.wagon.http.ssl.insecure=true -Dmaven.wagon.http.ssl.allowall=true -DskipTests  
+      export GLASSFISH=$QS_DIR/tmp/glassfish4/appserver/distributions/glassfish/target/stage/glassfish4
+    fi
+  fi
+
+  [[ -f $GLASSFISH/bin/asadmin && -x $GLASSFISH/bin/asadmin ]] || fatal "asadmin not found"
+}
+
+rm -rf $QS_DIR/tmp
+mkdir -p $QS_DIR/tmp
+
+build_gf
+build_narayana
+build_wf

--- a/ArjunaJTS/interop/glassfish/step2.sh
+++ b/ArjunaJTS/interop/glassfish/step2.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+source init.sh
+set -ex
+
+# start jboss and put it into JTS mode
+[ -d "$JBOSS_HOME"  ] || fatal "file not found: $JBOSS_HOME"
+cd $JBOSS_HOME
+./bin/standalone.sh -c standalone-full.xml -Djboss.tx.node.id=1 -Dcom.arjuna.ats.jts.transactionServiceId=0 &
+sleep 3
+./bin/jboss-cli.sh --connect --file=$QS_DIR/configure-jts-transactions.cli
+
+# shut it down using the script step7.sh

--- a/ArjunaJTS/interop/glassfish/step3.sh
+++ b/ArjunaJTS/interop/glassfish/step3.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+source init.sh
+set -ex
+
+# Start a glassfish server
+cd $QS_DIR
+
+export PATH=$GLASSFISH/bin:$PATH
+
+#asadmin start-domain --debug domain1 
+asadmin start-domain domain1
+asadmin set configs.config.server-config.network-config.network-listeners.network-listener.http-listener-1.port=7080
+

--- a/ArjunaJTS/interop/glassfish/step4.sh
+++ b/ArjunaJTS/interop/glassfish/step4.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+source init.sh
+set -ex
+
+cd $QS_DIR
+# deploy ejbs to glassfish
+./ejb_operations.sh -a gf1 -f ../test-ejbs/target/ejbtest.war
+
+# deploy ejbs to WildFly
+./ejb_operations.sh -a wf1 -f ../test-ejbs/target/ejbtest.war

--- a/ArjunaJTS/interop/glassfish/step5.sh
+++ b/ArjunaJTS/interop/glassfish/step5.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Make an ejb call from glassfish to wildfly
+
+./ejb_operations.sh -t gfwf

--- a/ArjunaJTS/interop/glassfish/step6.sh
+++ b/ArjunaJTS/interop/glassfish/step6.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Make an ejb call from glassfish to wildfly
+
+./ejb_operations.sh -t wfgf

--- a/ArjunaJTS/interop/glassfish/step7.sh
+++ b/ArjunaJTS/interop/glassfish/step7.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+source init.sh
+set -x
+set +e
+
+# undeploy ejbs and stop GlassFish
+export PATH=$GLASSFISH/bin:$PATH
+asadmin --port 4848 undeploy ejbtest
+asadmin stop-domain domain1
+
+# undeploy ejbs and stop WildFly
+[ -d "$JBOSS_HOME"  ] || fatal "file not found: $JBOSS_HOME"
+rm -f $JBOSS_HOME/standalone/deployments/ejbtest.war
+$JBOSS_HOME/bin/jboss-cli.sh --connect shutdown

--- a/ArjunaJTS/interop/pom.xml
+++ b/ArjunaJTS/interop/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+	JBoss, Home of Professional Open Source Copyright 2010, Red Hat
+	Middleware LLC, and others contributors as indicated by the @authors
+	tag. All rights reserved. See the copyright.txt in the distribution
+	for a full listing of individual contributors. This copyrighted
+	material is made available to anyone wishing to use, modify, copy, or
+	redistribute it subject to the terms and conditions of the GNU Lesser
+	General Public License, v. 2.1. This program is distributed in the
+	hope that it will be useful, but WITHOUT A WARRANTY; without even the
+	implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+	PURPOSE. See the GNU Lesser General Public License for more details.
+	You should have received a copy of the GNU Lesser General Public
+	License, v.2.1 along with this distribution; if not, write to the Free
+	Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+	02110-1301, USA.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.jboss.narayana.quickstart.jts</groupId>
+  <artifactId>jts-interop-quickstart</artifactId>
+  <version>5.5.6.Final-SNAPSHOT</version>
+  <name>JTS Interoperability Quickstart Parent pom</name>
+  <description>Transactional EJB calls between GlassFish and WildFly</description>
+  <packaging>pom</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.build.timestamp.format>yyyyMMdd'T'HHmmss</maven.build.timestamp.format>
+  </properties>
+
+  <licenses>
+    <license> 
+      <name>Apache License, Version 2.0</name>
+      <distribution>repo</distribution>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+    </license> 
+  </licenses> 
+
+  <repositories>
+    <repository>
+      <id>jboss-public-repository-group</id>
+      <name>JBoss Public Maven Repository Group</name>
+      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <modules>
+    <module>resource</module>
+    <module>test-ejbs</module>
+    <module>glassfish</module>
+  </modules>
+</project>

--- a/ArjunaJTS/interop/resource/pom.xml
+++ b/ArjunaJTS/interop/resource/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jboss.narayana.quickstart.jts</groupId>
+    <artifactId>jts-interop-quickstart</artifactId>
+    <version>5.5.6.Final-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>dummy-resources</artifactId>
+  <packaging>jar</packaging>
+  <name>dummy-resources</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>javax</groupId>
+      <artifactId>javaee-web-api</artifactId>
+      <version>6.0</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>dummy-resources</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.3.2</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>1.4</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/ArjunaJTS/interop/resource/src/main/java/org/jboss/narayana/ASFailureMode.java
+++ b/ArjunaJTS/interop/resource/src/main/java/org/jboss/narayana/ASFailureMode.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2008, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ *
+ * (C) 2008,
+ * @author JBoss Inc.
+ */
+package org.jboss.narayana;
+
+import java.io.Serializable;
+
+/**
+ * Specification of what to do when a failure is injected
+ */
+public enum ASFailureMode implements Serializable
+{
+    NONE(false)
+    
+    ,HALT(true)    // halt the JVM
+    ,EXIT(true)   // exit the JVM
+    ,SUSPEND(false)  // suspend the calling thread
+    ,XAEXCEPTION(false)    // fail via one of the xa exception codes
+    ;
+
+    private boolean willTerminateVM;
+
+    ASFailureMode(boolean willTerminateVM)
+    {
+        this.willTerminateVM = willTerminateVM;
+    }
+
+    public boolean willTerminateVM()
+    {
+        return willTerminateVM;
+    }
+
+    public static ASFailureMode toEnum(String mode)
+    {
+        return ASFailureMode.valueOf(mode.toUpperCase());
+    }
+}

--- a/ArjunaJTS/interop/resource/src/main/java/org/jboss/narayana/ASFailureSpec.java
+++ b/ArjunaJTS/interop/resource/src/main/java/org/jboss/narayana/ASFailureSpec.java
@@ -1,0 +1,120 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2008, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ *
+ * (C) 2008,
+ * @author JBoss Inc.
+ */
+package org.jboss.narayana;
+
+import java.io.Serializable;
+
+/**
+ * An ASFailureSpec is for defining different ways of generating
+ * failures and essentially consists of a mode and type.
+ *
+ * If you need to generate new kinds of failure you should
+ * modify the ASFailureMode and ASFailureType classes. Your
+ * test will be given a reference to these specifications and is
+ * responsible for interpreting their meaning.
+ *
+ */
+public class ASFailureSpec implements Serializable
+{
+    private String name;
+    private ASFailureMode mode;
+    private String modeArg;
+    private ASFailureType type;
+
+    public ASFailureSpec()
+    {
+        mode = ASFailureMode.NONE;
+        type = ASFailureType.NONE;
+    }
+
+    public ASFailureSpec(String name, ASFailureMode mode, String modeArg, ASFailureType type)
+    {
+        this.name = name;
+        this.mode = mode;
+        this.modeArg = modeArg;
+        this.type = type;
+    }
+
+    public boolean willTerminateVM()
+    {
+        return mode.willTerminateVM();
+    }
+
+    public ASFailureMode getMode()
+    {
+        return mode;
+    }
+
+    public ASFailureType getType()
+    {
+        return type;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public void setName(String name)
+    {
+        this.name = name;
+    }
+
+    public void setMode(String mode)
+    {
+        this.mode = ASFailureMode.valueOf(mode);
+    }
+
+    public String getModeArg() {
+        return modeArg;
+    }
+
+    public void setModeArg(String modeArg) {
+        this.modeArg = modeArg;
+    }
+
+    public void setType(String type)
+    {
+        this.type = ASFailureType.valueOf(type);
+    }
+
+    public String toString()
+    {
+        return new StringBuilder().append(mode).append(',').append(type).toString();
+    }
+
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (!(o instanceof ASFailureSpec)) return false;
+
+        ASFailureSpec that = (ASFailureSpec) o;
+
+        if (name != null ? !name.equals(that.name) : that.name != null) return false;
+
+        return true;
+    }
+
+    public int hashCode()
+    {
+        return (name != null ? name.hashCode() : 0);
+    }
+}

--- a/ArjunaJTS/interop/resource/src/main/java/org/jboss/narayana/ASFailureType.java
+++ b/ArjunaJTS/interop/resource/src/main/java/org/jboss/narayana/ASFailureType.java
@@ -1,0 +1,65 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2008, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ *
+ * (C) 2008,
+ * @author JBoss Inc.
+ */
+package org.jboss.narayana;
+
+import java.io.Serializable;
+
+/**
+ * Specification of when to inject a failure
+ */
+public enum ASFailureType implements Serializable
+{
+    NONE
+
+    ,PRE_PREPARE // do something before prepare is called
+
+    ,XARES_START    // failures specific to the XA protocol
+    ,XARES_END
+    ,XARES_PREPARE
+    ,XARES_ROLLBACK
+    ,XARES_COMMIT
+    ,XARES_RECOVER
+    ,XARES_FORGET
+
+    ,SYNCH_BEFORE   // do something before completion
+    ,SYNCH_AFTER
+    ;
+    
+    public static ASFailureType toEnum(String type)
+    {
+        return ASFailureType.valueOf(type.toUpperCase());
+    }
+
+    public boolean isXA()
+    {
+        return name().startsWith("XARES");
+    }
+
+    public boolean isSynchronization()
+    {
+        return name().startsWith("SYNCH");
+    }
+
+    public boolean isPreCommit()
+    {
+        return equals(PRE_PREPARE);
+    }
+}

--- a/ArjunaJTS/interop/resource/src/main/java/org/jboss/narayana/DummyXAResource.java
+++ b/ArjunaJTS/interop/resource/src/main/java/org/jboss/narayana/DummyXAResource.java
@@ -1,0 +1,402 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.narayana;
+
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+import java.io.ByteArrayOutputStream;
+
+import java.io.PrintWriter;
+import java.io.Serializable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Simulate a variety of faults during the various phases of the XA protocol
+ */
+public class DummyXAResource implements XAResource, Serializable // ,Synchronization
+{
+    private final static String XID_FNAME = "xids.txt";
+    private final static String XAR_LOG_FNAME = "xar.log";
+    private static final Map<String, XAException> xaCodeMap = new HashMap<String, XAException>();
+    private static XidStore xidStore = new XidStore(XID_FNAME);
+    private static XidStore traceLog = new XidStore(XAR_LOG_FNAME);
+
+    private ASFailureType _xaFailureType = ASFailureType.NONE;
+    private ASFailureMode _xaFailureMode = ASFailureMode.NONE;
+    private int _suspend;
+    private XAException _xaException;
+    private int txTimeout = 10;
+    private transient boolean _isPrepared = false; // transient so it doesn't get persisted in the tx store
+    private String _xid = null;
+
+    static
+    {
+        init();
+    }
+
+    public DummyXAResource()
+    {
+        this(new ASFailureSpec("default", ASFailureMode.NONE, "", ASFailureType.NONE));
+    }
+
+    public DummyXAResource(ASFailureSpec spec)
+    {
+        if (spec == null)
+            throw new IllegalArgumentException("Invalid XA resource failure injection specification");
+
+        setFailureMode(spec.getMode(), spec.getModeArg());
+        setFailureType(spec.getType());
+    }
+
+    public void applySpec(Xid xid, String message) throws XAException
+    {
+        applySpec(xid, message, _isPrepared);
+    }
+
+    public void applySpec(Xid xid, String message, boolean prepared) throws XAException
+    {
+        if (_xaFailureType.equals(ASFailureType.NONE) || _xaFailureMode.equals(ASFailureMode.NONE) || !prepared)
+        {
+            debug(xid, message + (_isPrepared ? " ... " : " recovery"));
+            return; // NB if !_isPrepared then we must have been called from the recovery subsystem
+        }
+
+        debug(xid, "Applying fault injection with active branches");
+        if (_xaException != null)
+        {
+            debug(xid, message + " ... xa error: " + _xaException.getMessage());
+            throw _xaException;
+        }
+        else if (_xaFailureMode.equals(ASFailureMode.HALT))
+        {
+            debug(xid, message + " ... halting");
+            Runtime.getRuntime().halt(1);
+        }
+        else if (_xaFailureMode.equals(ASFailureMode.EXIT))
+        {
+            debug(xid, message + " ... exiting");
+            System.exit(1);
+        }
+        else if (_xaFailureMode.equals(ASFailureMode.SUSPEND))
+        {
+            debug(xid, message + " ... suspending for " + _suspend);
+            suspend(_suspend);
+            debug(xid, message + " ... resuming");
+        }
+    }
+
+    public String toString()
+    {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("XAResourceWrapperImpl@").append(Integer.toHexString(System.identityHashCode(this)));
+        sb.append(" pad=").append("false");
+        sb.append(" overrideRmValue=").append("false");
+        sb.append(" productName=").append("Dummy Product");
+        sb.append(" productVersion=").append("0.0.0");
+        sb.append(" jndiName=").append("java:/dummyProd");
+        sb.append("]");
+
+        return sb.toString();
+    }
+
+    private void suspend(int msecs)
+    {
+        try
+        {
+            Thread.sleep(msecs);
+        }
+        catch (InterruptedException e)
+        {
+            e.printStackTrace();
+        }
+    }
+
+    public void setFailureMode(ASFailureMode mode, String ... args) throws IllegalArgumentException
+    {
+        _xaFailureMode = mode;
+
+        if (args != null && args.length != 0)
+        {
+            if (_xaFailureMode.equals(ASFailureMode.SUSPEND))
+            {
+                _suspend = Integer.parseInt(args[0]);
+            }
+            else if (_xaFailureMode.equals(ASFailureMode.XAEXCEPTION))
+            {
+                _xaException = xaCodeMap.get(args[0]);
+
+                if (_xaException == null)
+                    _xaException = new XAException(XAException.XAER_RMFAIL);
+            }
+        }
+    }
+
+    public void setFailureType(ASFailureType type)
+    {
+        _xaFailureType = type;
+    }
+
+    public ASFailureType getFailureType()
+    {
+        return _xaFailureType;
+    }
+
+    // Synchronizatons
+
+    public void beforeCompletion()
+    {
+        if (_xaFailureType.equals(ASFailureType.SYNCH_BEFORE))
+            try
+            {
+                applySpec(null, "Before completion");
+            }
+            catch (XAException e)
+            {
+                throw new RuntimeException(e);
+            }
+    }
+
+    public void afterCompletion(int i)
+    {
+
+        if (_xaFailureType.equals(ASFailureType.SYNCH_AFTER))
+            try
+            {
+                applySpec(null, "After completion");
+            }
+            catch (XAException e)
+            {
+                throw new RuntimeException(e);
+            }
+    }
+
+    private void debug(Xid xid, String message) {
+        debug(xid, false, message);
+    }
+
+    private void debug(Xid xid, boolean stackTrace, String message) {
+        String xidStr = xid != null ? new XidImpl(xid).formatString() : "";
+        System.out.printf("DummyXAResource: %s%n", message);
+
+        if (stackTrace)
+            System.out.println(getStackTrace(null));
+
+        try {
+            traceLog.write(s -> s, String.format(": [%s] %s %s",  Thread.currentThread().getName(), xidStr, message));
+        } catch (Exception ignore) {
+        }
+    }
+
+    // XA Interface implementation
+
+    public void commit(Xid xid, boolean b) throws XAException {
+        debug(xid, "commit");
+
+        if (_xaFailureType.equals(ASFailureType.XARES_COMMIT))
+            applySpec(xid, "xa commit");
+
+        _isPrepared = false;
+
+        try {
+            xidStore.remove(xid);
+        } catch (Exception ignore) {
+        }
+
+    }
+
+    public void rollback(Xid xid) throws XAException
+    {
+        debug(xid, true, "rollback");
+
+        if (_xaFailureType.equals(ASFailureType.XARES_ROLLBACK))
+            applySpec(xid, "xa rollback");
+
+        _isPrepared = false;
+        try {
+            xidStore.remove(xid);
+        } catch (Exception ignore) {
+        }
+    }
+
+    public void end(Xid xid, int i) throws XAException
+    {
+        debug(xid, "end");
+
+        if (_xaFailureType.equals(ASFailureType.XARES_END))
+            applySpec(xid, "xa end");
+    }
+
+    public void forget(Xid xid) throws XAException
+    {
+        debug(xid, "forget");
+
+        if (_xaFailureType.equals(ASFailureType.XARES_FORGET))
+            applySpec(xid, "xa forget");
+
+        _isPrepared = false;
+
+        try {
+            xidStore.remove(xid);
+        } catch (Exception ignore) {
+        }
+    }
+
+    public int getTransactionTimeout() throws XAException
+    {
+        return txTimeout;
+    }
+
+    public boolean isSameRM(XAResource xaResource) throws XAException
+    {
+        return xaResource instanceof DummyXAResource;  // the same resource is used for all recovery xids
+    }
+
+    public int prepare(Xid xid) throws XAException
+    {
+        debug(xid, "prepare");
+
+        _isPrepared = true;
+
+        if (_xaFailureType.equals(ASFailureType.XARES_PREPARE))
+            applySpec(xid, "xa prepare");
+
+        try {
+            xidStore.write(xid);
+        } catch (Exception ignore) {
+        }
+
+        return XA_OK;
+    }
+
+    public Xid[] recover(int i) throws XAException
+    {
+        if (_xaFailureType.equals(ASFailureType.XARES_RECOVER))
+            applySpec(null, "xa recover");
+
+        try {
+            List<Xid> xids = xidStore.read(new ArrayList<>());
+
+
+            return xids.toArray(new Xid[xids.size()]);
+        } catch (Exception ignore) {
+            return new Xid[0];
+        }
+    }
+
+    public boolean setTransactionTimeout(int txTimeout) throws XAException
+    {
+        this.txTimeout = txTimeout;
+
+        return true;    // set was successfull
+    }
+
+    public void start(Xid xid, int i) throws XAException
+    {
+        debug(xid, "start");
+
+        if (_xaFailureType.equals(ASFailureType.XARES_START))
+            applySpec(xid, "xa start");
+    }
+
+    public String getEISProductName() { return "Test XAResouce";}
+
+    public String getEISProductVersion() { return "v666.0";}
+
+    private String getStackTrace(Exception e) {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        PrintWriter writer = new PrintWriter(bytes, true);
+
+        if (e == null) {
+            Arrays.stream(Thread.currentThread().getStackTrace()).forEach(writer::println);
+        } else {
+            Throwable cause = e.getCause();
+
+            e.printStackTrace(writer);
+
+            while (cause != null) {
+                writer.write("Caused By:");
+                writer.println();
+                cause.printStackTrace(writer);
+                cause = cause.getCause();
+            }
+        }
+
+        return bytes.toString();
+    }
+
+    @SuppressWarnings({"ThrowableInstanceNeverThrown"})
+    private static void init()
+    {
+        xaCodeMap.put("XA_HEURCOM", new XAException(XAException.XA_HEURCOM));
+        xaCodeMap.put("XA_HEURHAZ", new XAException(XAException.XA_HEURHAZ));
+        xaCodeMap.put("XA_HEURMIX", new XAException(XAException.XA_HEURMIX));
+        xaCodeMap.put("XA_HEURRB", new XAException(XAException.XA_HEURRB));
+        xaCodeMap.put("XA_NOMIGRATE", new XAException(XAException.XA_NOMIGRATE));
+        xaCodeMap.put("XA_RBBASE", new XAException(XAException.XA_RBBASE));
+        xaCodeMap.put("XA_RBCOMMFAIL", new XAException(XAException.XA_RBCOMMFAIL));
+        xaCodeMap.put("XA_RBDEADLOCK", new XAException(XAException.XA_RBDEADLOCK));
+        xaCodeMap.put("XA_RBEND", new XAException(XAException.XA_RBEND));
+        xaCodeMap.put("XA_RBINTEGRITY", new XAException(XAException.XA_RBINTEGRITY));
+        xaCodeMap.put("XA_RBOTHER", new XAException(XAException.XA_RBOTHER));
+        xaCodeMap.put("XA_RBPROTO", new XAException(XAException.XA_RBPROTO));
+        xaCodeMap.put("XA_RBROLLBACK", new XAException(XAException.XA_RBROLLBACK));
+        xaCodeMap.put("XA_RBTIMEOUT", new XAException(XAException.XA_RBTIMEOUT));
+        xaCodeMap.put("XA_RBTRANSIENT", new XAException(XAException.XA_RBTRANSIENT));
+        xaCodeMap.put("XA_RDONLY", new XAException(XAException.XA_RDONLY));
+        xaCodeMap.put("XA_RETRY", new XAException(XAException.XA_RETRY));
+        xaCodeMap.put("XAER_ASYNC", new XAException(XAException.XAER_ASYNC));
+        xaCodeMap.put("XAER_DUPID", new XAException(XAException.XAER_DUPID));
+        xaCodeMap.put("XAER_INVAL", new XAException(XAException.XAER_INVAL));
+        xaCodeMap.put("XAER_NOTA", new XAException(XAException.XAER_NOTA));
+        xaCodeMap.put("XAER_OUTSIDE", new XAException(XAException.XAER_OUTSIDE));
+        xaCodeMap.put("XAER_PROTO", new XAException(XAException.XAER_PROTO));
+        xaCodeMap.put("XAER_RMERR", new XAException(XAException.XAER_RMERR));
+        xaCodeMap.put("XAER_RMFAIL ", new XAException(XAException.XAER_RMFAIL));
+    }
+
+    public boolean isXAResource()
+    {
+        return _xaFailureType.isXA() || _xaFailureType.equals(ASFailureType.NONE);
+    }
+
+    public boolean isSynchronization()
+    {
+        return _xaFailureType.isSynchronization();
+    }
+
+    public boolean isPreCommit()
+    {
+        return _xaFailureType.isPreCommit();
+    }
+
+    public boolean expectException()
+    {
+        return _xaFailureMode.equals(ASFailureMode.XAEXCEPTION);
+    }
+}

--- a/ArjunaJTS/interop/resource/src/main/java/org/jboss/narayana/XidImpl.java
+++ b/ArjunaJTS/interop/resource/src/main/java/org/jboss/narayana/XidImpl.java
@@ -1,0 +1,113 @@
+package org.jboss.narayana;
+
+import javax.transaction.xa.Xid;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Base64;
+
+public class XidImpl implements Xid, Serializable {
+    private int formatId;
+    byte[] globalTransactionId;
+    byte[] branchQualifier;
+
+    public XidImpl(Xid xid) {
+        formatId = xid.getFormatId();
+        globalTransactionId = xid.getGlobalTransactionId();
+        branchQualifier = xid.getBranchQualifier();
+    }
+
+    public XidImpl(String xid) {
+        try {
+            XidImpl o = (XidImpl) XidImpl.fromString(xid);
+
+            formatId = o.getFormatId();
+            globalTransactionId = o.getGlobalTransactionId();
+            branchQualifier = o.getBranchQualifier();
+        } catch (Exception e) {
+            System.out.printf("XidImpl: deserialize error %s%n", e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof XidImpl)) return false;
+
+        XidImpl xid = (XidImpl) o;
+
+        if (formatId != xid.formatId) return false;
+        if (!Arrays.equals(branchQualifier, xid.branchQualifier)) return false;
+        if (!Arrays.equals(globalTransactionId, xid.globalTransactionId)) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = formatId;
+        result = 31 * result + Arrays.hashCode(globalTransactionId);
+        result = 31 * result + Arrays.hashCode(branchQualifier);
+        return result;
+    }
+
+    @Override
+    public int getFormatId() {
+        return formatId;
+    }
+
+    @Override
+    public byte[] getGlobalTransactionId() {
+        return globalTransactionId;
+    }
+
+    @Override
+    public byte[] getBranchQualifier() {
+        return branchQualifier;
+    }
+
+    /**
+     * Write the object to a Base64 string.
+     */
+    @Override
+    public String toString() {
+        try {
+            return XidImpl.toString(this);
+        } catch (IOException e) {
+            return formatString();
+       }
+    }
+
+    public String formatString() {
+        return "XidImpl{" +
+                "formatId=" + formatId +
+                ", globalTransactionId=" + Arrays.toString(globalTransactionId) +
+                ", branchQualifier=" + Arrays.toString(branchQualifier) +
+                '}';
+    }
+
+    /** Read the object from Base64 string. */
+    public static Object fromString( String s ) throws IOException, ClassNotFoundException {
+        byte[] data = Base64.getDecoder().decode( s );
+        ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(  data ) );
+        Object o  = ois.readObject();
+        ois.close();
+
+        return o;
+    }
+
+    /** Write the object to a Base64 string. */
+    public static String toString( Serializable o ) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream( baos );
+        oos.writeObject( o );
+        oos.close();
+        return Base64.getEncoder().encodeToString(baos.toByteArray());
+    }
+
+}

--- a/ArjunaJTS/interop/resource/src/main/java/org/jboss/narayana/XidStore.java
+++ b/ArjunaJTS/interop/resource/src/main/java/org/jboss/narayana/XidStore.java
@@ -1,0 +1,99 @@
+package org.jboss.narayana;
+
+import javax.transaction.xa.Xid;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.nio.channels.FileLock;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.nio.file.StandardOpenOption.APPEND;
+
+public class XidStore {
+    private String xidFileName = "xids.txt";
+
+    public XidStore(String xidFileName) {
+         this.xidFileName = xidFileName;
+    }
+
+    public static void main(String[] args) throws Exception {
+    }
+
+    public boolean write(Xid ... lines) throws Exception {
+        return write((Xid xid) -> new XidImpl(xid).toString(), lines);
+    }
+
+    @SafeVarargs
+    public final <T> boolean write(Function<T, String> typeToString, T... lines) throws Exception {
+        FileOutputStream fos= new FileOutputStream(xidFileName, true);
+        FileLock fl = fos.getChannel().lock();
+
+        List<String> xidList = Arrays.stream(lines).map(typeToString).collect(Collectors.toList());
+
+        if (fl != null) {
+            try {
+                try {
+                    Files.write(Paths.get(xidFileName), xidList, StandardCharsets.UTF_8, APPEND);
+                    return true;
+                } finally {
+                    fl.release();
+                }
+            } finally {
+                fos.close();
+            }
+        }
+
+        return false;
+
+    }
+
+    public List<Xid> read(List<Xid> lines) throws Exception {
+        FileInputStream fos= new FileInputStream(xidFileName);
+        FileLock fl = fos.getChannel().tryLock(0L, Long.MAX_VALUE, true);
+
+        try {
+            if (fl != null) {
+                try {
+                    Files.readAllLines(Paths.get(xidFileName)).forEach((String item) -> lines.add(new XidImpl(item)));
+                } finally {
+                    fl.release();
+                }
+            }
+        } finally{
+            fos.close();
+        }
+
+        return lines;
+    }
+
+    public void remove(Xid xid) throws Exception {
+        FileInputStream fos= new FileInputStream(xidFileName);
+        FileLock fl = fos.getChannel().tryLock(0L, Long.MAX_VALUE, true);
+
+        try {
+            if (fl != null) {
+                List<String> lines = new ArrayList<>();
+
+                try {
+                    lines.addAll(Files.readAllLines(Paths.get(xidFileName)));
+
+                    if (lines.remove(new XidImpl(xid).toString())) {
+                        Files.write(Paths.get(xidFileName), lines);
+                    }
+
+                } finally {
+                    fl.release();
+                }
+            }
+        } finally{
+            fos.close();
+        }
+    }
+}

--- a/ArjunaJTS/interop/test-ejbs/pom.xml
+++ b/ArjunaJTS/interop/test-ejbs/pom.xml
@@ -1,0 +1,168 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jboss.narayana.quickstart.jts</groupId>
+    <artifactId>jts-interop-quickstart</artifactId>
+    <version>5.5.6.Final-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>ejbtest</artifactId>
+  <packaging>war</packaging>
+  <name>interop-test-ejbs</name>
+  <description>interop test ejbs</description>
+
+   <licenses>
+      <license>
+         <name>Apache License, Version 2.0</name>
+         <distribution>repo</distribution>
+         <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+      </license>
+   </licenses>
+
+   <properties>
+      <!-- Explicitly declaring the source encoding eliminates the following 
+         message: -->
+      <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
+         resources, i.e. build is platform dependent! -->
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+   </properties>
+
+   <dependencyManagement>
+      <dependencies>
+         <!-- Define the version of JBoss' Java EE 6 APIs we want to import. 
+            Any dependencies from org.jboss.spec will have their version defined by this 
+            BOM -->
+         <!-- JBoss distributes a complete set of Java EE 6 APIs including
+            a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
+            a collection) of artifacts. We use this here so that we always get the correct
+            versions of artifacts. Here we use the jboss-javaee-6.0 stack (you can
+            read this as the JBoss stack of the Java EE 6 APIs). You can actually
+            use this stack with any version of JBoss AS that implements Java EE 6, not
+            just JBoss AS 7! -->
+         <dependency>
+            <groupId>org.jboss.spec</groupId>
+            <artifactId>jboss-javaee-6.0</artifactId>
+            <version>3.0.0.Final</version>
+            <type>pom</type>
+            <scope>import</scope>
+         </dependency>
+      </dependencies>
+   </dependencyManagement>
+
+   <dependencies>
+      <dependency>
+         <groupId>org.jboss.narayana.quickstart.jts</groupId>
+         <artifactId>dummy-resources</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+         <groupId>org.jboss.spec.javax.transaction</groupId>
+         <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+         <scope>provided</scope>
+      </dependency>
+
+      <!-- Import the CDI API, we use provided scope as the API is included 
+         in JBoss AS 7 -->
+      <dependency>
+         <groupId>javax.enterprise</groupId>
+         <artifactId>cdi-api</artifactId>
+         <scope>provided</scope>
+      </dependency>
+
+      <!-- Import the Common Annotations API (JSR-250), we use provided scope 
+         as the API is included in JBoss AS 7 -->
+      <dependency>
+         <groupId>org.jboss.spec.javax.annotation</groupId>
+         <artifactId>jboss-annotations-api_1.1_spec</artifactId>
+         <scope>provided</scope>
+      </dependency>
+
+      <!-- Import the JAX-RS API, we use provided scope as the API is included 
+         in JBoss AS 7 -->
+      <dependency>
+         <groupId>org.jboss.spec.javax.ws.rs</groupId>
+         <artifactId>jboss-jaxrs-api_1.1_spec</artifactId>
+         <scope>provided</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.jboss.spec.javax.ejb</groupId>
+         <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+         <scope>provided</scope>
+      </dependency>
+
+   </dependencies>
+
+   <build>
+      <!-- Set the name of the war, used as the context root when the app 
+         is deployed -->
+      <finalName>${project.artifactId}</finalName>
+      <plugins>
+         <plugin>
+            <artifactId>maven-war-plugin</artifactId>
+            <version>2.1.1</version>
+            <configuration>
+               <!-- Java EE 6 doesn't require web.xml, Maven needs to catch 
+                  up! -->
+               <failOnMissingWebXml>false</failOnMissingWebXml>
+            </configuration>
+         </plugin>
+         <!-- JBoss AS plugin to deploy war -->
+         <plugin>
+            <groupId>org.jboss.as.plugins</groupId>
+            <artifactId>jboss-as-maven-plugin</artifactId>
+            <version>7.1.1.Final</version>
+         </plugin>
+         <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
+            annotation processors -->
+         <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>2.3.1</version>
+            <configuration>
+               <source>1.8</source>
+               <target>1.8</target>
+            </configuration>
+         </plugin>
+         <plugin>
+           <groupId>org.apache.maven.plugins</groupId>
+           <artifactId>maven-source-plugin</artifactId>
+           <executions>
+             <execution>
+               <id>attach-sources</id>
+               <goals>
+                 <goal>jar</goal>
+               </goals>
+             </execution>
+           </executions>
+         </plugin>
+      </plugins>
+   </build>
+
+   <profiles>
+      <profile>
+         <!-- When built in OpenShift the 'openshift' profile will be used when invoking mvn. -->
+         <!-- Use this profile for any OpenShift specific customization your app will need. -->
+         <!-- By default that is to put the resulting archive into the 'deployments' folder. -->
+         <!-- http://maven.apache.org/guides/mini/guide-building-for-different-environments.html -->
+         <id>openshift</id>
+         <build>
+            <plugins>
+               <plugin>
+                  <artifactId>maven-war-plugin</artifactId>
+                  <version>2.1.1</version>
+                  <configuration>
+                     <outputDirectory>deployments</outputDirectory>
+                     <warName>ROOT</warName>
+                     <!-- Java EE 6 doesn't require web.xml, Maven needs to catch up! -->
+                     <failOnMissingWebXml>false</failOnMissingWebXml>
+                  </configuration>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+   </profiles>
+</project>
+

--- a/ArjunaJTS/interop/test-ejbs/src/main/java/service/Controller.java
+++ b/ArjunaJTS/interop/test-ejbs/src/main/java/service/Controller.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package service;
+
+import javax.inject.Inject;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Response;
+
+@Path("/")
+public class Controller {
+	@Inject
+	ControllerBean service;
+
+	@GET
+	@Path("/local/{arg}")
+	public String getLocalNextCount(@DefaultValue("") @PathParam("arg") String arg) {
+		return "Next: " + service.getNext(true, arg);
+	}
+
+	@GET
+	@Path("/remote/{jndiPort}")
+	public Response getRemoteNextCount(@DefaultValue("0") @PathParam("jndiPort") int jndiPort) {
+		return getRemoteNextCountWithASAndError(jndiPort, null, null);
+	}
+
+	@GET
+	@Path("/remote/{jndiPort}/{as}/{failureType}")
+	public Response getRemoteNextCountWithASAndError(
+			@DefaultValue("0") @PathParam("jndiPort") int jndiPort,
+			@DefaultValue("") @PathParam("as") String as,
+			@PathParam("failureType") String failureType) {
+		return Response.status(200)
+				.entity("Next: " + service.getNext(false, as, jndiPort, failureType))
+				.build();
+	}
+}

--- a/ArjunaJTS/interop/test-ejbs/src/main/java/service/ControllerBean.java
+++ b/ArjunaJTS/interop/test-ejbs/src/main/java/service/ControllerBean.java
@@ -1,0 +1,155 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package service;
+
+import org.omg.CORBA.ORB;
+import service.remote.ISession;
+import service.remote.ISessionHome;
+
+import javax.annotation.PostConstruct;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.ejb.TransactionManagement;
+import javax.ejb.TransactionManagementType;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import java.util.Properties;
+
+@TransactionManagement(TransactionManagementType.CONTAINER)
+@Stateless
+public class ControllerBean {
+
+    private boolean isWF;
+
+    @PostConstruct
+    public void init() {
+        isWF = System.getProperty("jboss.node.name") != null;
+        System.setProperty("com.sun.CORBA.ORBUseDynamicStub", "true");
+    }
+
+    @TransactionAttribute(TransactionAttributeType.REQUIRED)
+    public String getNext(boolean local, String arg) {
+        return getNext(local, null, 0, arg);
+    }
+
+    @TransactionAttribute(TransactionAttributeType.REQUIRED)
+    public String getNext(boolean local, String as, int jndiPort, String failureType) {
+        try {
+            boolean enlistAfter = failureType != null && failureType.contains("after");
+
+            if (!enlistAfter)
+                TxnHelper.addResources(isWF);
+
+            String res = "";
+            for (ISession ejb : getServiceEJBs(local, as, jndiPort))
+                res = ejb.getNext(failureType);
+
+            if (enlistAfter)
+                TxnHelper.addResources(isWF);
+
+            return res;
+        } catch (Exception e) {
+            return e.getMessage();
+        }
+    }
+
+    private ISession[] getServiceEJBs(boolean local, String as, int jndiPort) {
+        if (!local && !isWF && as != null && as.contains("gf") && as.contains("wf")) {
+            ISession[] ejbs = new ISession[2];
+            ejbs[0] = getServiceEJB(false, "gf", jndiPort);
+            ejbs[1] = getServiceEJB(false, "wf", jndiPort);
+
+            return ejbs;
+        } else {
+            return new ISession[] {getServiceEJB(local, as, jndiPort)};
+        }
+    }
+
+    private int validateJndiPort(int jndiPort, int defaultPort) {
+        return (jndiPort <= 0 ? defaultPort : jndiPort);
+    }
+
+    private ISession getServiceEJB(boolean local, String as, int jndiPort) {
+        // "java:global/[<application-name>]/<module-name>/<bean-name>!<fully-qualified-bean-interface-name>"
+        String name = "java:global/ejbtest/SessionBean!service.remote.ISessionHome";
+        Properties env = new Properties();
+
+        if (!local) {
+            if (isWF) {
+                // running on a WildFly server
+                if ("wf".equals(as)) {
+                    jndiPort = validateJndiPort(jndiPort, 3628); // corba name service port for wildfly server2
+
+                    name = "ejbtest/SessionBean";
+                } else {
+                    jndiPort = validateJndiPort(jndiPort, 7001); // corba name service port for glassfish domain1
+                }
+
+                env.put(Context.PROVIDER_URL, String.format("corbaloc::localhost:%d/NameService", jndiPort));
+                env.put(Context.INITIAL_CONTEXT_FACTORY, "org.wildfly.iiop.openjdk.naming.jndi.CNCtxFactory");
+
+            } else {
+                // running on a glassfish server
+                if ("gf".equals(as)) { // lookup an ejb running on a glassfish server
+
+                    jndiPort = validateJndiPort(jndiPort, 3700); // corba name service port for glassfish domain2
+
+                    env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.enterprise.naming.SerialInitContextFactory");
+                    env.setProperty("org.omg.CORBA.ORBInitialHost", "localhost");
+                    env.setProperty("org.omg.CORBA.ORBInitialPort", String.valueOf(jndiPort));
+
+                } else {  // lookup an ejb running on a wildfly server
+                    name = "ejbtest/SessionBean";
+
+                    jndiPort = validateJndiPort(jndiPort, 3528); // default corba name service port for wildfly
+
+                    env.put(Context.PROVIDER_URL, String.format("iiop://localhost:%d", jndiPort));
+                    env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.cosnaming.CNCtxFactory");
+
+                    try {
+                        ORB orb = (ORB) new InitialContext().lookup("java:comp/ORB");
+                        env.put("java.naming.corba.orb", orb);
+                    } catch (NamingException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        }
+
+        try {
+            System.out.printf("looking up %s via port %d%n", name, jndiPort);
+            InitialContext ctx = new InitialContext(env);
+
+            Object oRef = ctx.lookup(name);
+            ISessionHome home = (ISessionHome) oRef; //PortableRemoteObject.narrow(oRef, ISessionHome.class);
+
+            return home.create();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return null;
+    }
+}

--- a/ArjunaJTS/interop/test-ejbs/src/main/java/service/SessionBean.java
+++ b/ArjunaJTS/interop/test-ejbs/src/main/java/service/SessionBean.java
@@ -1,0 +1,68 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package service;
+
+import service.remote.ISessionHome;
+
+import javax.annotation.PostConstruct;
+import javax.ejb.RemoteHome;
+
+import javax.ejb.Stateless;
+
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.ejb.TransactionManagement;
+import javax.ejb.TransactionManagementType;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Stateless
+@RemoteHome(ISessionHome.class)
+@TransactionManagement(TransactionManagementType.CONTAINER)
+public class SessionBean {
+	static AtomicInteger counter = new AtomicInteger(0);
+	boolean isWF;
+
+	@PostConstruct
+	public void init() {
+		isWF = System.getProperty("jboss.node.name") != null;
+
+		counter.set(isWF ? 8000 : 7000);
+	}
+
+	@TransactionAttribute(TransactionAttributeType.MANDATORY)
+	public String getNext() {
+		return getNext(null);
+	}
+
+	@TransactionAttribute(TransactionAttributeType.MANDATORY)
+	public String getNext(String failureType) {
+		try {
+			TxnHelper.addResources(isWF, failureType);
+
+			System.out.printf("%s returning next counter%n", this);
+			return String.valueOf(counter.getAndIncrement());
+		} catch (Exception e) {
+			throw new RuntimeException(e.getMessage());
+		}
+	}
+}

--- a/ArjunaJTS/interop/test-ejbs/src/main/java/service/TxnHelper.java
+++ b/ArjunaJTS/interop/test-ejbs/src/main/java/service/TxnHelper.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package service;
+
+import org.jboss.narayana.ASFailureMode;
+import org.jboss.narayana.ASFailureSpec;
+import org.jboss.narayana.ASFailureType;
+import org.jboss.narayana.DummyXAResource;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
+import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
+
+public class TxnHelper {
+    static private final String WL_TM = "weblogic.transaction.TransactionManager";
+    static private final String EE_TM = "java:/TransactionManager";
+    static private final String GF_TM = "java:appserver/TransactionManager";
+
+    static void addResources(boolean isWF) throws NamingException, SystemException, RollbackException {
+        addResources(isWF, null);
+    }
+
+    static void addResources(boolean isWF, String failureType) throws NamingException, SystemException, RollbackException {
+        TransactionManager tm = getTransactionManager(isWF);
+
+        assert tm.getTransaction() != null;
+
+        tm.getTransaction().enlistResource(getResource(tm, failureType));
+    }
+
+    static TransactionManager getTransactionManager(boolean isWF) throws NamingException {
+        if (isWF)
+            return (TransactionManager) new InitialContext().lookup(EE_TM);
+        else
+            return (TransactionManager) new InitialContext().lookup(GF_TM);
+    }
+
+    static Transaction getTransaction(boolean isWF) throws NamingException, SystemException {
+        return getTransactionManager(isWF).getTransaction();
+    }
+
+    static private DummyXAResource getResource(TransactionManager tm, String failureType) {
+        if (failureType == null || tm == null)
+            return new DummyXAResource();
+
+        System.out.printf("enlisting dummy resource with fault type %s%n", failureType);
+
+        if (failureType.contains("halt"))
+            return new DummyXAResource(new ASFailureSpec("fault", ASFailureMode.HALT, "", ASFailureType.XARES_COMMIT));
+        else
+            return new DummyXAResource(new ASFailureSpec("", ASFailureMode.NONE, "", ASFailureType.NONE));
+    }
+}

--- a/ArjunaJTS/interop/test-ejbs/src/main/java/service/local/ISession.java
+++ b/ArjunaJTS/interop/test-ejbs/src/main/java/service/local/ISession.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package service.local;
+
+import javax.ejb.Local;
+
+// Extending remote interface for convenience of method declaration
+@Local
+public interface ISession extends service.remote.ISession {
+}

--- a/ArjunaJTS/interop/test-ejbs/src/main/java/service/remote/ISession.java
+++ b/ArjunaJTS/interop/test-ejbs/src/main/java/service/remote/ISession.java
@@ -1,0 +1,11 @@
+package service.remote;
+
+import javax.ejb.Remote;
+import java.rmi.RemoteException;
+
+//@Remote
+public interface ISession extends javax.ejb.EJBObject {
+    String getNext() throws RemoteException;
+
+    String getNext(String failureType) throws RemoteException;
+}

--- a/ArjunaJTS/interop/test-ejbs/src/main/java/service/remote/ISessionHome.java
+++ b/ArjunaJTS/interop/test-ejbs/src/main/java/service/remote/ISessionHome.java
@@ -1,0 +1,5 @@
+package service.remote;
+
+public interface ISessionHome extends javax.ejb.EJBHome {
+   public service.remote.ISession create() throws java.rmi.RemoteException;
+}

--- a/ArjunaJTS/interop/test-ejbs/src/main/webapp/WEB-INF/beans.xml
+++ b/ArjunaJTS/interop/test-ejbs/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,8 @@
+<!-- Marker file indicating CDI 1.0 should be enabled -->
+
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="
+      http://java.sun.com/xml/ns/javaee 
+      http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+</beans>

--- a/ArjunaJTS/interop/test-ejbs/src/main/webapp/WEB-INF/jboss-ejb3.xml
+++ b/ArjunaJTS/interop/test-ejbs/src/main/webapp/WEB-INF/jboss-ejb3.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<jboss:ejb-jar xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
+               xmlns="http://java.sun.com/xml/ns/javaee"
+               xmlns:iiop="urn:iiop"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-2_0.xsd
+                  http://java.sun.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-spec-2_0.xsd
+                  urn:iiop http://www.jboss.org/j2ee/schema/jboss-ejb-iiop_1_0.xsd"
+               version="3.1"
+               impl-version="2.0">
+    <assembly-descriptor>
+        <iiop:iiop>
+            <ejb-name>SessionBean</ejb-name>
+            <iiop:binding-name>ejbtest/SessionBean</iiop:binding-name>
+        </iiop:iiop>
+    </assembly-descriptor>
+</jboss:ejb-jar>

--- a/ArjunaJTS/interop/test-ejbs/src/main/webapp/WEB-INF/web.xml
+++ b/ArjunaJTS/interop/test-ejbs/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,19 @@
+<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+    <!-- One of the way of activating REST Servises is adding these lines, the server is responsible for adding the corresponding servlet automatically. If the src folder, org.jboss.as.quickstarts.rshelloworld.HelloWorld class has the Annotations to receive REST invocation-->
+<!--
+    <servlet-mapping>
+        <servlet-name>javax.ws.rs.core.Application</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+-->
+        <servlet>
+            <servlet-name>javax.ws.rs.core.Application</servlet-name>
+            <load-on-startup>1</load-on-startup>
+        </servlet>
+        <servlet-mapping>
+            <servlet-name>javax.ws.rs.core.Application</servlet-name>
+            <url-pattern>/rs/*</url-pattern>
+        </servlet-mapping>
+</web-app>

--- a/ArjunaJTS/pom.xml
+++ b/ArjunaJTS/pom.xml
@@ -128,6 +128,7 @@
     </dependency>
   </dependencies>
   <modules>
+    <module>interop</module>
     <module>trailmap</module>
     <module>recovery</module>
     <module>standalone</module>

--- a/build.sh
+++ b/build.sh
@@ -167,6 +167,9 @@ main() {
     #  Setup some build properties
     MVN_OPTS="$MVN_OPTS -Dbuild.script=$0"
 
+    #  un in non-interactive (batch) mode
+    MVN_OPTS="$MVN_OPTS -B"
+
     #  Change to the directory where the script lives, so users are not forced
     #  to be in the same directory as build.xml.
     cd $DIRNAME

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
     <url>https://github.com/jbosstm/quickstart</url>
   </scm>
   <modules>
+    <module>ArjunaJTS</module>
     <module>jca-and-tomcat</module>
     <module>jca-and-hibernate</module>
     <module>jta-1_2-standalone</module>
@@ -131,11 +132,11 @@
     <module>spring</module>
     <module>ArjunaCore</module>
     <module>ArjunaJTA</module>
-    <module>ArjunaJTS</module>
     <module>compensating-transactions</module>
     <module>rts</module>
     <module>XTS</module>
-    <module>blacktie</module>
+    <!-- see JBTM-2878 -->
+    <!-- module>blacktie</module> -->
     <module>wildfly/setCheckedActionFactoryExample</module>
     <module>STM</module>
     <module>jts-docker</module>

--- a/scripts/hudson/quickstart.sh
+++ b/scripts/hudson/quickstart.sh
@@ -17,6 +17,14 @@
 
 #!/bin/bash
 
+function fatal {
+  echo "$1"; exit 1
+}
+
+[ $WORKSPACE ] || fatal "please set WORKSPACE to the quickstarts directory"
+NARAYANA_REPO=jbosstm
+NARAYANA_BRANCH="master"
+
 function comment_on_pull
 {
     if [ "$COMMENT_ON_PULL" = "" ]; then return; fi
@@ -31,87 +39,112 @@ function comment_on_pull
     fi
 }
 
+function int_env {
+  cd $WORKSPACE
+  export GIT_ACCOUNT=jbosstm
+  export GIT_REPO=quickstart
+  export MFACTOR=2 # double wait timeout period for crash recovery QA tests
 
-export GIT_ACCOUNT=jbosstm
-export GIT_REPO=quickstart
-export MFACTOR=2 # double wait timeout period for crash recovery QA tests
+  [ $NARAYANA_CURRENT_VERSION ] || export NARAYANA_CURRENT_VERSION="5.6.0.Final-SNAPSHOT" 
 
-PULL_NUMBER=$(echo $GIT_BRANCH | awk -F 'pull' '{ print $2 }' | awk -F '/' '{ print $2 }')
-PULL_DESCRIPTION=$(curl -ujbosstm-bot:$BOT_PASSWORD -s https://api.github.com/repos/$GIT_ACCOUNT/$GIT_REPO/pulls/$PULL_NUMBER)
-if [[ $PULL_DESCRIPTION =~ "\"state\": \"closed\"" ]]; then
-  echo "pull closed"
-  exit 0
-fi
+  PULL_NUMBER=$(echo $GIT_BRANCH | awk -F 'pull' '{ print $2 }' | awk -F '/' '{ print $2 }')
+  PULL_DESCRIPTION=$(curl -ujbosstm-bot:$BOT_PASSWORD -s https://api.github.com/repos/$GIT_ACCOUNT/$GIT_REPO/pulls/$PULL_NUMBER)
+  if [[ $PULL_DESCRIPTION =~ "\"state\": \"closed\"" ]]; then
+    echo "pull closed"
+    exit 0
+  fi
+}
 
+function rebase_quickstart_repo {
+  cd $WORKSPACE
+  git remote add upstream https://github.com/jbosstm/quickstart.git
+  export BRANCHPOINT=master
+  git branch $BRANCHPOINT origin/$BRANCHPOINT
+  git pull --rebase --ff-only origin $BRANCHPOINT
+  if [ $? -ne 0 ]; then
+    comment_on_pull "Narayana rebase on $BRANCHPOINT failed. Please rebase it manually: $BUILD_URL"
+  fi
+}
 
+function get_bt_dependencies {
+  cd $WORKSPACE
+  # SCP Blacktie thirdparty dependencies centos70x64
+  set +e
+  uname -a | grep el7 >> /dev/null
+  if [ "$?" -ne "1" ]; then
+  DEP=`find  ~/.m2 -name '*centos70x64*.md5'|grep -v blacktie|wc -l`
+      if [ "$DEP" -ne "6" ]; then
+      wget http://${JENKINS_HOST}/userContent/blacktie-thirdparty-centos70x64.tgz
+      tar xzvf blacktie-thirdparty-centos70x64.tgz
+      fi
+  fi
+}
+
+function build_narayana {
+  cd $WORKSPACE
+  # INITIALIZE ENV
+  export MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=512m"
+
+  [ $PROFILE ] || PROFILE=BLACKTIE 
+
+  #rm -rf ~/.m2/repository/
+  rm -rf narayana
+  git clone https://github.com/${NARAYANA_REPO}/narayana.git
+  if [ $? != 0 ]; then
+    comment_on_pull "Checkout failed: $BUILD_URL";
+    exit -1
+  fi
+  cd narayana
+  WORKSPACE=$PWD COMMENT_ON_PULL="" PROFILE=$PROFILE ./scripts/hudson/narayana.sh -DskipTests -Pcommunity
+  if [ $? != 0 ]; then
+    comment_on_pull "Narayana build failed: $BUILD_URL";
+    exit -1
+  fi
+}
+
+function configure_wildfly {
+  cd $WORKSPACE
+  WILDFLY_MASTER_VERSION=10.1.0.Final
+  rm -rf wildfly-$WILDFLY_MASTER_VERSION
+  wget -N http://download.jboss.org/wildfly/$WILDFLY_MASTER_VERSION/wildfly-$WILDFLY_MASTER_VERSION.zip
+  unzip wildfly-$WILDFLY_MASTER_VERSION.zip
+  export JBOSS_HOME=$PWD/wildfly-$WILDFLY_MASTER_VERSION
+  cp $JBOSS_HOME/docs/examples/configs/standalone-xts.xml $JBOSS_HOME/standalone/configuration/
+  cp $JBOSS_HOME/docs/examples/configs/standalone-rts.xml $JBOSS_HOME/standalone/configuration/
+}
+
+function build_apache-karaf {
+  cd $WORKSPACE
+  git clone https://github.com/apache/karaf.git apache-karaf
+  if [ $? != 0 ]; then
+    comment_on_pull "Karaf clone failed: $BUILD_URL";
+    exit -1
+  fi
+  ./build.sh -f apache-karaf/pom.xml -Pfastinstall
+  if [ $? != 0 ]; then
+    comment_on_pull "Karaf build failed: $BUILD_URL";
+    exit -1
+  fi
+}
+
+function run_quickstarts {
+  cd $WORKSPACE
+  echo Running quickstarts
+  BLACKTIE_DIST_HOME=$PWD/narayana/blacktie/blacktie/target/ ./build.sh -B clean install -DskipX11Tests=true
+
+  if [ $? != 0 ]; then
+    comment_on_pull "Pull failed: $BUILD_URL";
+    exit -1
+  else
+    comment_on_pull "Pull passed: $BUILD_URL"
+  fi
+}
+
+int_env
 comment_on_pull "Started testing this pull request: $BUILD_URL"
-
-git remote add upstream https://github.com/jbosstm/quickstart.git
-export BRANCHPOINT=master
-git branch $BRANCHPOINT origin/$BRANCHPOINT
-git pull --rebase --ff-only origin $BRANCHPOINT
-if [ $? -ne 0 ]; then
-  comment_on_pull "Narayana rebase on $BRANCHPOINT failed. Please rebase it manually: $BUILD_URL"
-fi
-
-
-# SCP Blacktie thirdparty dependencies centos70x64
-set +e
-uname -a | grep el7 >> /dev/null
-if [ "$?" -ne "1" ]; then
-DEP=`find  ~/.m2 -name '*centos70x64*.md5'|grep -v blacktie|wc -l`
-    if [ "$DEP" -ne "6" ]; then
-    cd ~
-    wget http://${JENKINS_HOST}/userContent/blacktie-thirdparty-centos70x64.tgz
-    tar xzvf blacktie-thirdparty-centos70x64.tgz
-    cd -
-    fi
-fi
-
-# INITIALIZE ENV
-export MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=512m"
-
-#rm -rf ~/.m2/repository/
-rm -rf narayana
-git clone https://github.com/jbosstm/narayana.git
-if [ $? != 0 ]; then
-  comment_on_pull "Checkout failed: $BUILD_URL";
-  exit -1
-fi
-cd narayana
-WORKSPACE=$PWD COMMENT_ON_PULL="" PROFILE=BLACKTIE ./scripts/hudson/narayana.sh -DskipTests -Pcommunity
-if [ $? != 0 ]; then
-  comment_on_pull "Narayana build failed: $BUILD_URL";
-  exit -1
-fi
-
-WILDFLY_MASTER_VERSION=10.1.0.Final
-
-rm -rf wildfly-$WILDFLY_MASTER_VERSION
-wget -N http://download.jboss.org/wildfly/$WILDFLY_MASTER_VERSION/wildfly-$WILDFLY_MASTER_VERSION.zip
-unzip wildfly-$WILDFLY_MASTER_VERSION.zip
-export JBOSS_HOME=$PWD/wildfly-$WILDFLY_MASTER_VERSION
-cp $JBOSS_HOME/docs/examples/configs/standalone-xts.xml $JBOSS_HOME/standalone/configuration/
-cp $JBOSS_HOME/docs/examples/configs/standalone-rts.xml $JBOSS_HOME/standalone/configuration/
-
-# JBTM-2820 disable the karaf build
-#git clone https://github.com/apache/karaf.git apache-karaf
-#if [ $? != 0 ]; then
-#  comment_on_pull "Karaf clone failed: $BUILD_URL";
-#  exit -1
-#fi
-#./build.sh -f apache-karaf/pom.xml -Pfastinstall
-#if [ $? != 0 ]; then
-#  comment_on_pull "Karaf build failed: $BUILD_URL";
-#  exit -1
-#fi
-
-echo Running quickstarts
-BLACKTIE_DIST_HOME=$PWD/narayana/blacktie/blacktie/target/ ./build.sh clean install -DskipX11Tests=true
-
-if [ $? != 0 ]; then
-  comment_on_pull "Pull failed: $BUILD_URL";
-  exit -1
-else
-  comment_on_pull "Pull passed: $BUILD_URL"
-fi
+rebase_quickstart_repo
+#get_bt_dependencies # JBTM-2878 missing userContent on JENKINS_HOST
+build_narayana
+configure_wildfly
+#build_apache-karaf # JBTM-2820 disable the karaf build
+run_quickstarts


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-2874
https://issues.jboss.org/browse/JBTM-2878

The quickstart shows how to make transactional EJB calls from WildFly to GlassFish and vice versa. It does it in 7 steps:

1. step1.sh:
  - builds GlassFish either from source (using svn) or via prebuild binaries. The build from source also needs patching using the included patch file;
  - builds narayana using the latest version (controlled by the environment variable NARAYANA_CURRENT_VERSION)
  - patches and builds the WildFly version downloaded during the narayana build. The patch disables the interceptor that blocks the importing of foreign transactions
2. step2.sh: starts WildFly in JTS mode
3. step3.sh: starts a GlassFish domain
4. step4.sh: deploys the test EJB to both servers (for making transactional calls between them)
5. step5.sh: Make an ejb call from GlassFish to WildFly (using the script in d.sh)
6. step6.sh: Make an ejb call from WildFly to GlassFish (using the script in d.sh)
7. step7.sh: Undeploy EJBs and shutdown GlassFish and WildFly

