### PR TITLE
Changes to run wsat multi quickstart on two containers

### DIFF
--- a/XTS/wsat-jta-multi_service/pom.xml
+++ b/XTS/wsat-jta-multi_service/pom.xml
@@ -45,6 +45,8 @@
         <jvm.args.debug></jvm.args.debug>
         <jvm.args.other>-server</jvm.args.other>
         <version.surefire.plugin>2.19.1</version.surefire.plugin>
+        <jboss1.home>${env.JBOSS_HOME_1}</jboss1.home>
+        <jboss2.home>${env.JBOSS_HOME_2}</jboss2.home>
     </properties>
 
     <!-- We add the JBoss repository as we need the JBoss AS connectors
@@ -221,6 +223,8 @@
                                 -->
                                 <server.jvm.args>${jvm.args.other} ${jvm.args.memory} ${jvm.args.debug}</server.jvm.args>
                                 <node.address>127.0.0.1</node.address>
+                                <jboss1.home>${jboss1.home}</jboss1.home>
+                                <jboss2.home>${jboss2.home}</jboss2.home>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
@@ -256,7 +260,66 @@
                                 <node.address>[::1]</node.address>
                             </systemPropertyVariables>
                             <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                            <jboss1.home>${jboss1.home}</jboss1.home>
+                            <jboss2.home>${jboss2.home}</jboss2.home>
                         </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <!-- To get two instances of JBOSS_HOME directory for tests -->
+        <profile>
+            <id>make.jboss1.home.directory</id>
+            <activation>
+                <property>
+                    <name>!env.JBOSS_HOME_1</name>
+                </property>
+                <file>
+                    <missing>${basedir}/target/jboss1</missing>
+                </file>
+            </activation>
+            <properties>
+                <jboss1.home>${basedir}/target/jboss1</jboss1.home>
+                <jboss2.home>${basedir}/target/jboss2</jboss2.home>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <version>2.6</version>
+                        <executions>
+                            <execution>
+                                <id>copy-resources-jboss1</id>
+                                <phase>test-compile</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${jboss1.home}</outputDirectory>
+                                    <resources>
+                                        <resource>
+                                            <directory>${env.JBOSS_HOME}</directory>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>copy-resources-jboss2</id>
+                                <phase>test-compile</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${jboss2.home}</outputDirectory>
+                                    <resources>
+                                        <resource>
+                                            <directory>${env.JBOSS_HOME}</directory>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/XTS/wsat-jta-multi_service/src/test/java/org/jboss/narayana/quickstarts/wsat/jtabridge/fromjta/SecondClient.java
+++ b/XTS/wsat-jta-multi_service/src/test/java/org/jboss/narayana/quickstarts/wsat/jtabridge/fromjta/SecondClient.java
@@ -29,7 +29,7 @@ import java.net.URL;
 public class SecondClient {
 
     public static SecondServiceAT newInstance() throws Exception {
-        URL wsdlLocation = new URL("http://localhost:8080/test/SecondServiceATService/SecondServiceAT?wsdl");
+        URL wsdlLocation = new URL("http://localhost:8180/test/SecondServiceATService/SecondServiceAT?wsdl");
         QName serviceName = new QName("http://www.jboss.org/narayana/quickstarts/wsat/simple/second", "SecondServiceATService");
         QName portName = new QName("http://www.jboss.org/narayana/quickstarts/wsat/simple/second", "SecondServiceAT");
 

--- a/XTS/wsat-jta-multi_service/src/test/resources/arquillian.xml
+++ b/XTS/wsat-jta-multi_service/src/test/resources/arquillian.xml
@@ -25,21 +25,35 @@
             xsi:schemaLocation="http://jboss.org/schema/arquillian
         http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
+     <!-- Force the use of the Servlet 3.0 protocol with all containers, as it is the most mature -->
+	<defaultProtocol type="Servlet 3.0"/>
+
+    <group qualifier="jboss-containers" default="true">
+
+	    <container qualifier="jboss1" default="true">
+	        <configuration>
+	            <property name="jbossHome">${jboss1.home:target/jboss1}</property>
+	            <property name="javaVmArguments">${server.jvm.args}</property>
+	            <property name="serverConfig">standalone-xts.xml</property>
+	            <property name="managementAddress">${node.address}</property>
+	        </configuration>
+	    </container>
+
+	    <container qualifier="jboss2">
+	        <configuration>
+	            <property name="jbossHome">${jboss2.home:target/jboss2}</property>
+	            <property name="javaVmArguments">${server.jvm.args} -Djboss.socket.binding.port-offset=100</property>
+	            <property name="serverConfig">standalone-xts.xml</property>
+	            <property name="managementAddress">${node.address}</property>
+	            <property name="managementPort">10090</property> <!-- for arquillian to know where to connect to, it's 9990 + 100 -->
+	        </configuration>
+	    </container>
+	</group>
+
     <!-- Uncomment to have test archives exported to the file system for inspection -->
-    <engine>
+    <!-- <engine>
         <property name="deploymentExportPath">target/</property>
     </engine>
-
-    <!-- Force the use of the Servlet 3.0 protocol with all containers, as it is the most mature -->
-    <defaultProtocol type="Servlet 3.0"/>
-
-    <!-- Example configuration for a remote JBoss AS 7 instance -->
-    <container qualifier="jboss" default="true">
-        <configuration>
-            <property name="javaVmArguments">${server.jvm.args}</property>
-            <property name="serverConfig">standalone-xts.xml</property>
-            <property name="managementAddress">${node.address}</property>
-        </configuration>
-    </container>
+    -->
 
 </arquillian>


### PR DESCRIPTION
for checking customer case CASE#01952249 there is change to set up
arquillian to use two containers to run the wsat mutli quicstart

the first container contains the tests and starts the runtime from it
the second only receives the XTS calls and joins the transaction by that