### PR TITLE
Showcase of using transactional driver - recovery additions

### DIFF
--- a/transactionaldriver/transactionaldriver-standalone/pom.xml
+++ b/transactionaldriver/transactionaldriver-standalone/pom.xml
@@ -45,10 +45,10 @@
             <version>${version.h2}</version>
         </dependency>
         <dependency> <!-- for XA testing purposes -->
-		    <groupId>org.postgresql</groupId>
-		    <artifactId>postgresql</artifactId>
-		    <version>42.1.4.jre7</version>
-		</dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.1.4.jre7</version>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -79,8 +79,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <!-- <argLine>-Dcom.arjuna.ats.arjuna.recovery.periodicRecoveryPeriod=15 -Dcom.arjuna.ats.arjuna.recovery.recoveryBackoffPeriod=5</argLine> -->
-                    <argLine>-Dorg.jboss.byteman.verbose -Dorg.jboss.byteman.debug=true</argLine>
+                    <argLine>-Dcom.arjuna.ats.arjuna.recovery.periodicRecoveryPeriod=5 -Dcom.arjuna.ats.arjuna.recovery.recoveryBackoffPeriod=3</argLine>
+                    <!-- <argLine>-Dorg.jboss.byteman.verbose -Dorg.jboss.byteman.debug=true</argLine>  -->
                </configuration>
             </plugin>
         </plugins>

--- a/transactionaldriver/transactionaldriver-standalone/src/main/java/io/narayana/recovery/Ds1XAResourceRecovery.java
+++ b/transactionaldriver/transactionaldriver-standalone/src/main/java/io/narayana/recovery/Ds1XAResourceRecovery.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package io.narayana.recovery;
+
+import java.sql.SQLException;
+import javax.sql.XAConnection;
+import javax.transaction.xa.XAResource;
+
+import com.arjuna.ats.internal.jta.recovery.arjunacore.XARecoveryModule;
+import com.arjuna.ats.jta.recovery.XAResourceRecovery;
+import io.narayana.util.DBUtils;
+
+/**
+ * Simple {@link XAResourceRecovery} class which provides {@link XAResource}
+ * for specific log in data. In this case it's just for particular database.
+ * <br>
+ * Still this helps {@link XARecoveryModule} tocheck indoubt transaction at database side
+ * and try to match them to transaction in the transaction log store.
+ */
+public class Ds1XAResourceRecovery implements XAResourceRecovery {
+
+    private XAConnection xaConn;
+    private boolean wasReturned = false;
+
+    @Override
+    public XAResource getXAResource() throws SQLException {
+        if(xaConn == null) {
+            xaConn = DBUtils.getXADatasource(DBUtils.DB_1).getXAConnection();
+        }
+        return xaConn.getXAResource();
+    }
+
+    @Override
+    public boolean initialise(String p) throws SQLException {
+        return true;
+    }
+
+    @Override
+    public boolean hasMoreResources() {
+        wasReturned = !wasReturned;
+        return wasReturned;
+    }
+
+}

--- a/transactionaldriver/transactionaldriver-standalone/src/main/java/io/narayana/recovery/RecoverySetupUtil.java
+++ b/transactionaldriver/transactionaldriver-standalone/src/main/java/io/narayana/recovery/RecoverySetupUtil.java
@@ -43,7 +43,7 @@ import io.narayana.util.TestInitialContextFactory;
 /**
  * <p>
  * Utility class which gathers the approaches for recovery setup
- * for jdbc transactional driver. 
+ * for jdbc transactional driver.
  * <p>
  * All the settings of recovery (recovery modules, filters, timeouts ) are taken
  * from <code>jbossts-properties.xml</code> descriptor.
@@ -62,6 +62,28 @@ public final class RecoverySetupUtil {
      * and that where info for new connection is taken from.
      */
     public static RecoveryManager simpleRecoveryIntialize() {
+        RecoveryManager manager = RecoveryManager.manager(RecoveryManager.DIRECT_MANAGEMENT);
+        manager.initialize();
+
+        return manager;
+    }
+
+    /**
+     * <p>
+     * Starting recovery manager to be run manually (not periodically)
+     * <p>
+     * Setting up the programatically property <code>com.arjuna.ats.jta.recovery.XAResourceRecovery</code>
+     * (can be done in <code>jbossts-properties.xml</code> or via JVM parameter).<br>
+     * <p>
+     * Here we intialize XAResourceRecovery which we created for particular database.
+     * It creates connection to the specific database and returns {@link XAResource}
+     * to check indoubt transactions in database.
+     */
+    public static RecoveryManager ds1XARecoveryIntialize() {
+        jtaPropertyManager.getJTAEnvironmentBean().setXaResourceRecoveryClassNames(Arrays.asList(
+                Ds1XAResourceRecovery.class.getName()));
+
+        // direct management means it's not run periodically but we has to manually run recovery scan
         RecoveryManager manager = RecoveryManager.manager(RecoveryManager.DIRECT_MANAGEMENT);
         manager.initialize();
 
@@ -131,6 +153,6 @@ public final class RecoverySetupUtil {
      */
     public static void runRecovery(RecoveryManager manager) {
         manager.scan();
-        manager.terminate(false);
+        manager.terminate();
     }
 }

--- a/transactionaldriver/transactionaldriver-standalone/src/main/java/io/narayana/util/DBUtils.java
+++ b/transactionaldriver/transactionaldriver-standalone/src/main/java/io/narayana/util/DBUtils.java
@@ -139,7 +139,7 @@ public class DBUtils {
         ds.setPassword(DB_H2_PASSWORD);
         return ds;
     }
-    
+
     private static XADataSource getPgXADatasource(String dbName) {
         PGXADataSource ds = new PGXADataSource();
         ds.setServerName(DB_PG_HOST);

--- a/transactionaldriver/transactionaldriver-standalone/src/main/resources/jbossts-properties.xml
+++ b/transactionaldriver/transactionaldriver-standalone/src/main/resources/jbossts-properties.xml
@@ -34,8 +34,8 @@
     <entry key="CoordinatorEnvironmentBean.commitOnePhase">YES</entry>
 
     <!-- default is under user.home - must be writeable!) -->
+    <!-- for the test purposes we want  the temporary data being placed in target directory -->
     <entry key="ObjectStoreEnvironmentBean.objectStoreDir">target</entry>
-    <entry key="com.arjuna.ats.arjuna.objectstore.objectStoreDir">target</entry>
 
     <!-- (default is ON) -->
     <entry key="ObjectStoreEnvironmentBean.transactionSync">ON</entry>
@@ -45,11 +45,6 @@
 
     <!-- Which Xid types to recover -->
     <entry key="JTAEnvironmentBean.xaRecoveryNodes">1</entry>
-
-    <entry key="JTAEnvironmentBean.xaResourceOrphanFilterClassNames">
-        com.arjuna.ats.internal.jta.recovery.arjunacore.JTATransactionLogXAResourceOrphanFilter
-        com.arjuna.ats.internal.jta.recovery.arjunacore.JTANodeNameXAResourceOrphanFilter
-    </entry>
 
     <!--
       Base port number for determining a unique number to associate with an instance of the transaction service
@@ -68,28 +63,59 @@
          Check http://www.jboss.org/community/docs/DOC-10788 for more information
          on recovery modules and their configuration when running in various
          deployments.
+         ===
+         NOTE: for testing purposes reset at TransactionalDriverTest#tearDown
     -->
     <entry key="RecoveryEnvironmentBean.recoveryModuleClassNames">
         com.arjuna.ats.internal.arjuna.recovery.AtomicActionRecoveryModule
         com.arjuna.ats.internal.jta.recovery.arjunacore.XARecoveryModule
     </entry>
+        <!-- if transaction manager could be used in subordinate role (which is not likely on jdbc driver usage)
+        use the following order of recovery modules
+        com.arjuna.ats.internal.arjuna.recovery.AtomicActionRecoveryModule
+        com.arjuna.ats.internal.txoj.recovery.TORecoveryModule
+        com.arjuna.ats.internal.jta.recovery.arjunacore.SubordinateAtomicActionRecoveryModule
+        com.arjuna.ats.internal.jta.recovery.arjunacore.XARecoveryModule
+    -->
 
     <!-- Expiry scanners to use (order of invocation is random). -->
     <entry key="RecoveryEnvironmentBean.expiryScannerClassNames">
         com.arjuna.ats.internal.arjuna.recovery.ExpiredTransactionStatusManagerScanner
     </entry>
-
-    <!-- Registering XAResourceRecovery to get registered handler capable to recover jdbc XAResources -->
-        <!--com.arjuna.ats.internal.jdbc.recovery.JDBCXARecovery;target/classes/recovery-jdbcxa-test2.xml-->
-    <!--<entry key="com.arjuna.ats.jta.recovery.XAResourceRecovery">
-        com.arjuna.ats.internal.jdbc.recovery.BasicXARecovery;target/classes/recovery-basicxa-test1.xml;1
-    </entry> -->
-
     <!--
         Add the following to the set of expiryScannerClassNames above to move logs that cannot be completed by failure recovery.
             But be sure you know what you are doing and why!
              com.arjuna.ats.internal.arjuna.recovery.AtomicActionExpiryScanner
     -->
+
+    <entry key="JTAEnvironmentBean.xaResourceOrphanFilterClassNames">
+        com.arjuna.ats.internal.jta.recovery.arjunacore.JTATransactionLogXAResourceOrphanFilter
+        com.arjuna.ats.internal.jta.recovery.arjunacore.JTANodeNameXAResourceOrphanFilter
+    </entry>
+    <!-- if transaction manager could be used in subordinate role (which is not likely on jdbc driver usage add the
+        com.arjuna.ats.internal.jta.recovery.arjunacore.SubordinationManagerXAResourceOrphanFilter
+    -->
+
+
+    <!-- Registering XAResourceRecovery to get registered handler capable to recover jdbc XAResources.
+         The responsible bean for this configuration is: com.arjuna.ats.jta.common.JTAEnvironmentBean
+     -->
+    <!--
+        <entry key="com.arjuna.ats.jta.recovery.XAResourceRecovery">
+            com.arjuna.ats.internal.jdbc.recovery.JDBCXARecovery;target/classes/recovery-jdbcxa-test2.xml
+        </entry>
+    -->
+    <!--
+        <entry key="com.arjuna.ats.jta.recovery.XAResourceRecovery">
+            com.arjuna.ats.internal.jdbc.recovery.BasicXARecovery;target/classes/recovery-basicxa-test1.xml;1
+        </entry>
+    -->
+    <!--
+        <entry key="com.arjuna.ats.jta.recovery.XAResourceRecovery">
+            io.narayana.recovery.Ds1XAResourceRecovery
+        </entry>
+    -->
+
 
     <!--
       For cases where the recovery manager is in process with the transaction manager and nothing else uses
@@ -98,8 +124,33 @@
       if you are not careful. That in turn can lead to incorrect transaction processing. Use with care.
     -->
     <entry key="RecoveryEnvironmentBean.recoveryListener">NO</entry>
+   <!--
+      The address and port number on which the recovery manager listens,
+      if the prior settings is YES
+    -->
+    <entry key="RecoveryEnvironmentBean.recoveryPort">4712</entry>
+    <entry key="RecoveryEnvironmentBean.recoveryAddress"></entry>
 
-    <entry key="RecoveryEnvironmentBean.periodicRecoveryPeriod">5</entry>
-    <entry key="RecoveryEnvironmentBean.recoveryBackoffPeriod">3</entry>
+    <!-- Should be transaction status manager started and available at some port? (default YES) -->
+    <entry key="CoordinatorEnvironmentBean.transactionStatusManagerEnable">YES</entry>
+    <!--
+      Use this to fix the port on which the TransactionStatusManager listens,
+      The default behaviour is to use any free port.
+    -->
+    <entry key="RecoveryEnvironmentBean.transactionStatusManagerPort">0</entry>
+
+    <!--
+      Use this to fix the address on which the TransactionStatusManager binds,
+      The default behaviour is to use the loopback address (ie localhost).
+      If running within an AS then the address the AS is bound to (jboss.bind.address) takes precedence
+    -->
+    <entry key="RecoveryEnvironmentBean.transactionStatusManagerAddress"></entry>
+
+
+    <!-- Example for the testing purposes, expected to be left commented and the default values will be used -->
+    <!--
+        <entry key="RecoveryEnvironmentBean.periodicRecoveryPeriod">5</entry>
+        <entry key="RecoveryEnvironmentBean.recoveryBackoffPeriod">3</entry>
+    -->
 
 </properties>


### PR DESCRIPTION
For the transactiona-driver-standalone quickstart cleaning the recovery
functionality and adding a simple XAResourceRecovery class
for further presentation.

Follow-up to https://github.com/jbosstm/quickstart/pull/217

This should be followed by another blog post about transactional driver (as preivous one https://jbossts.blogspot.cz/2017/12/narayana-jdbc-transactional-driver.html) and recovery.