### PR TITLE
[SCRIPT ONLY] get build lra plus using wfly nightly build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ apache-tomcat-*
 narayana-full-*-bin.zip
 jboss*/
 bin/
+db/

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ target/
 /tools/maven.zip
 
 .DS_Store
+ObjectStore/
 
 instantclient_11_2/
 jboss-as
@@ -20,6 +21,7 @@ instantclient-sdk-win32-11.2.0.1.0.zip
 wildfly-10.x.zip
 wildfly-10.*/
 wildfly-10.*.jar
+apache-tomcat-*
 narayana-full-*-bin.zip
 jboss*/
 bin/

--- a/ArjunaJTS/interop/glassfish/step1.sh
+++ b/ArjunaJTS/interop/glassfish/step1.sh
@@ -14,7 +14,7 @@ function build_wf {
 
   git apply $QS_DIR/interop.wildfly.diff
 
-  ./build.sh clean install -B -DskipTests -Drelease=true -Dlicense.skipDownloadLicenses=true -Dversion.org.jboss.narayana=$NARAYANA_CURRENT_VERSION
+  ./build.sh clean install -B -DskipTests -Dversion.org.jboss.narayana=$NARAYANA_CURRENT_VERSION
   
 
   WILDFLY_MASTER_VERSION=`awk '/wildfly-parent/ { while(!/<version>/) {getline;} print; }' pom.xml | cut -d \< -f 2|cut -d \> -f 2`

--- a/rts/at/jta-service/jpa/src/main/resources/META-INF/persistence.xml
+++ b/rts/at/jta-service/jpa/src/main/resources/META-INF/persistence.xml
@@ -29,6 +29,7 @@
       <jta-data-source>java:jboss/datasources/RestTXBridgeJPAQuickstartDS</jta-data-source>
       <properties>
          <!-- Properties for Hibernate -->
+         <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
          <property name="hibernate.hbm2ddl.auto" value="create-drop" />
          <property name="hibernate.show_sql" value="false" />
       </properties>

--- a/rts/at/jta-service/jpa/src/main/webapp/WEB-INF/test-ds.xml
+++ b/rts/at/jta-service/jpa/src/main/webapp/WEB-INF/test-ds.xml
@@ -24,7 +24,7 @@
     <xa-datasource jndi-name="java:jboss/datasources/RestTXBridgeJPAQuickstartDS"
                    pool-name="RestTXBridgeJPAQuickstartDS">
         <xa-datasource-class>org.h2.jdbcx.JdbcDataSource</xa-datasource-class>
-        <xa-datasource-property name="URL">jdbc:h2:file:db/rest-tx-bridge-jpa-quickstart;DB_CLOSE_ON_EXIT=FALSE
+        <xa-datasource-property name="URL">jdbc:h2:file:./db/rest-tx-bridge-jpa-quickstart;DB_CLOSE_ON_EXIT=FALSE
         </xa-datasource-property>
         <driver>h2</driver>
         <security>

--- a/scripts/hudson/quickstart.sh
+++ b/scripts/hudson/quickstart.sh
@@ -25,7 +25,7 @@ function fatal {
 NARAYANA_REPO=${NARAYANA_REPO:-jbosstm}
 NARAYANA_BRANCH="${NARAYANA_BRANCH:-master}"
 QUICKSTART_NARAYANA_VERSION=${QUICKSTART_NARAYANA_VERSION:-5.8.3.Final-SNAPSHOT}
-MICROPROFILE_LRA_BRANCH=${MICROPROFILE_LRA_BRANCH:-microprofile-lra}
+MICROPROFILE_LRA_BRANCH=${MICROPROFILE_LRA_BRANCH:-microprofile-lra-v2}
 
 function comment_on_pull
 {
@@ -125,9 +125,9 @@ function build_narayana {
   fi
   cd narayana
   build_microprofile_lra
-  ./build.sh clean install -DskipTests -Pcommunity
-  ./build.sh -f blacktie/wildfly-blacktie/pom.xml clean install
-  ./build.sh -f blacktie/pom.xml clean install -DskipTests
+  ./build.sh clean install -B -DskipTests -Pcommunity
+  ./build.sh -f blacktie/wildfly-blacktie/pom.xml clean install -B
+  ./build.sh -f blacktie/pom.xml clean install -B -DskipTests
   
   if [ $? != 0 ]; then
     comment_on_pull "Narayana build failed: $BUILD_URL";
@@ -141,11 +141,11 @@ function build_narayana {
 
 function configure_wildfly {
   cd $WORKSPACE
-  WILDFLY_MASTER_VERSION=10.1.0.Final
-  rm -rf wildfly-$WILDFLY_MASTER_VERSION
-  wget -N http://download.jboss.org/wildfly/$WILDFLY_MASTER_VERSION/wildfly-$WILDFLY_MASTER_VERSION.zip
-  unzip wildfly-$WILDFLY_MASTER_VERSION.zip
-  export JBOSS_HOME=$PWD/wildfly-$WILDFLY_MASTER_VERSION
+  wget --user=guest --password=guest -nv https://ci.wildfly.org/httpAuth/repository/downloadAll/WF_Nightly/.lastSuccessful/artifacts.zip
+  unzip -q artifacts.zip
+  export WILDFLY_DIST_ZIP=$(ls wildfly-*-SNAPSHOT.zip)
+  unzip -q $WILDFLY_DIST_ZIP
+  export JBOSS_HOME=`pwd`/${WILDFLY_DIST_ZIP%.zip}
   cp $JBOSS_HOME/docs/examples/configs/standalone-xts.xml $JBOSS_HOME/standalone/configuration/
   cp $JBOSS_HOME/docs/examples/configs/standalone-rts.xml $JBOSS_HOME/standalone/configuration/
 }
@@ -157,7 +157,7 @@ function build_apache-karaf {
     comment_on_pull "Karaf clone failed: $BUILD_URL";
     exit -1
   fi
-  ./build.sh -f apache-karaf/pom.xml -Pfastinstall
+  ./build.sh -f apache-karaf/pom.xml -B -Pfastinstall
   if [ $? != 0 ]; then
     comment_on_pull "Karaf build failed: $BUILD_URL";
     exit -1


### PR DESCRIPTION
* fixing lra branch name to get the quickstart built
* using maven and wget non-interactive mode (`-B`) for not printing processing while downloading artifacts
* using WFLY nightly build not a static WFLY version defined in the script
* get built the wildfly in interop directory for testing with glassfish (see https://github.com/jbosstm/narayana/pull/1322)