### PR TITLE
Commit markable resource quickstart: adding link to blogpost

### DIFF
--- a/wildfly/commit-markable-resource/README.adoc
+++ b/wildfly/commit-markable-resource/README.adoc
@@ -14,6 +14,8 @@ two phase commit processing.
 
 CMR is availale only for JDBC datasources. It's *not* for available for an _arbitrary_ resource.
 
+Complementary blog post with all the details is at http://jbossts.blogspot.com/2018/06/narayana-commit-markable-resource.html.
+
 === LRCO data inconsisency window
 
 The problem when the LRCO fails to guarantee the data consistency is case


### PR DESCRIPTION
This is (only) addition of link to blogpost about CMR to cmr quickstart README.adoc.