### PR TITLE
JBTM-3063 LRA examples

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,1 @@
+Except where otherwise noted, files in this repository are licensed under the Apache License 2.0. If you use these quickstarts in your own projects, you need not comply with any of the notice requirements of the Apache License.

--- a/rts/lra-examples/README.md
+++ b/rts/lra-examples/README.md
@@ -1,0 +1,343 @@
+# MicroProfile LRA Examples
+
+[MicroProfile LRA](https://github.com/eclipse/microprofile-lra) is a specification of an API that
+enables loosely coupled services to coordinate long running activities in such a way as to
+guarantee a globally consistent outcome without the need to take long duration locks on data.
+
+
+These examples take a normal WAR and wraps it into a -swarm runnable jar.
+
+Each project uses maven war packagin in the `pom.xml`
+
+    <packaging>war</packaging>
+
+amd adds a `<plugin>` to configure `wildfly-swarm-plugin` to
+create the runnable `.jar`:
+
+```
+    <plugin>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>wildfly-swarm-plugin</artifactId>
+      <version>${version.wildfly-swarm}</version>
+      <executions>
+        <execution>
+          <goals>
+            <goal>package</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
+```
+
+Five quickstarts are included:
+
+## cdi-participant-with-coordinator
+
+[Shows a service which registers with an embedded LRA coordinator using CDI annotations](#cdi-participant-with-coordinator/README.md) 
+
+## cdi-participant
+
+[Shows a service which registers with an external LRA coordinator using CDI annotations](#cdi-participant/README.md)
+
+## api-participant-with-coordinator
+
+[Shows a service which registers with an embedded LRA coordinator using the Java LRA API (instead of annotations) to start and end an LRA and for joining the LRA](#api-participant-with-coordinator/README.md)
+
+## api-participant
+
+[Shows a service which registers with an external LRA coordinator using the Java LRA API (instead of annotations) to start and end an LRA and for joining the LRA](#api-participant/README.md)
+
+## mixed-participant-with-coordinator
+
+[Shows a service which starts an LRA and then invokes the CDI and API based examples using JAX-RS calls.](#mixed-participant-with-coordinator/README.md)
+
+## Running an external LRA coordinator
+
+The maven module `lra-coordinator` contains a project for building a swarm jar that runs a
+standalone LRA coordinator. The port on which the coordinator listens for requests is defined
+by the system property `swarm.http.port`. The coordinator relies on persistent storage for
+creating logs in order to be able to recover from failures. Normally swarm uses a temporary
+directory for its logs which is not useful in recovery situations since the storage
+so you need to overide this default using the following system property:
+
+> -Dswarm.transactions.object-store-path=../txlogs
+
+So, assuming you are in the lra-examples directory, to start a coordinator type:
+
+> java -Dswarm.http.port=8080 -Dswarm.transactions.object-store-path=../txlogs -jar lra-coordinator/target/lra-coordinator-swarm.jar
+
+## Running the cdi-participant-with-coordinator example
+
+This example includes a dependency on the org.jboss.narayana.rts:lra-coordinator maven artefact
+in the project pom:
+
+```
+        <dependency>
+            <groupId>org.jboss.narayana.rts</groupId>
+            <artifactId>lra-coordinator</artifactId>
+            <version>${project.version}</version>
+            <type>war</type>
+        </dependency>
+```
+
+The JAX-RS service code is identical to the `cdi-participant` example. In fact the service code
+is pulled in via the pom dependency on that example:
+
+```
+        <dependency>
+            <groupId>org.jboss.narayana.quickstart.rts.lra</groupId>
+            <artifactId>examples-microprofile-lra-cdi-participant</artifactId>
+            <version>${project.version}</version>
+            <type>war</type>
+        </dependency>
+```
+
+Including the artefact will result in a coordinator being co-located with the service.
+
+### The successful path
+
+Start the service on port 8080. Since the example uses an embedded coordinator, make sure you use
+non temporary storage for the logs using the `swarm.transactions.object-store-path` system property.
+Also set the system property, `swarm.http.port`,  which defines the port the coordinator on which
+it will accept requests (since the coordinator and service are co-located you must ensure that port
+for the service and the coordinator are the same).
+
+> java -Dswarm.http.port=8080 -Dlra.http.port=8080 -Dswarm.transactions.object-store-path=../txlogs -jar cdi-participant-with-coordinator/target/lra-participant-example-swarm.jar
+
+In another terminal send a request to the service using curl:
+
+> curl -X PUT -I http://localhost:8080/cdi
+
+<pre>
+HTTP/1.1 204 No Content
+Date: Sun, 14 Oct 2018 10:51:15 GMT
+</pre>
+
+This invokes a service method which is annotated with `@LRA(LRA.Type.REQUIRED)`. This annotation will
+result in an LRA being started before the method called. Since the service resource is annotated with
+`@Complete` and `@Compensate` annotations the resource will be also be enlisted in the new LRA before
+the method is invoked.
+
+When the method finishes the LRA is automatically terminated and the `@Complete` method will be invoked.
+If you look at the implementation of this callback you should notice that it prints a count of how many
+times it has been notified. This output should be visible in the terminal where you started the service.
+
+You can also ask the service how many times it has been notified:
+
+> curl http://localhost:8080/cdi
+
+which should report
+
+<pre>
+1 completed and 0 compensated   
+</pre>
+
+### Recovery from failure
+
+Inject a fault into the service causing it to halt:
+
+> curl -X PUT -I http://localhost:8080/cdi?fault=haltcdiduring
+
+<pre>
+curl: (52) Empty reply from server
+</pre>
+
+and you should notice that service console prints:
+
+<pre>
+2018-10-14 12:09:19,451 INFO  [stdout] (default task-11) injecting fault type HALT ..
+</pre>
+
+and there should be a pending record in the transaction logs which should appear under the
+following directory:
+
+> /tmp/txlogs/ShadowNoFileLockStore/defaultStore/StateManager/BasicAction/TwoPhaseCoordinator/LRA/
+
+Now restart the service and wait for recovery to complete the LRA and call the service completion callback:
+
+> java -Dswarm.http.port=8080 -Dlra.http.port=8080 -Dswarm.transactions.object-store-path=../txlogs -jar target/lra-participant-example-swarm.jar
+
+The recovery system can take a few minutes to recover the state or you can trigger an immediate
+recovery scan using a curl request:
+
+> curl http://localhost:8080/lra-recovery-coordinator/recovery
+
+This command will attempt to recover any pending LRA's. If any participant involved with the LRA is
+unavailable this request will print the id of the corresponding LRA. But if the participant is
+available then it should return success allowing the LRA to complete and you should see something
+similar to the following printed in the service console:
+
+> 2018-10-14 17:38:51,831 INFO  [stdout] (default task-3) 1 completions
+
+Sometimes it can take more than one recovery pass to recover an LRA. If the recovery command returns
+more than zero pending LRA's then you should rerun the recover command.
+
+And you can confirm that the service did indeed complete by sending the query:
+
+> curl  http://localhost:8080/cdi
+
+which should result in the following output:
+
+<pre>
+1 completed and 0 compensated
+</pre>
+
+## Running the cdi-participant example
+
+This example is similar to the cdi-participant-with-coordinator example except that it
+uses an external coordinator.
+
+The example requires the Eclipse MicroProfile LRA annotations and the name of the JAX-RS
+header that exposes the id of any LRA context during JAX-RS invocations:
+
+
+```
+        <dependency>
+            <groupId>io.narayana.microprofile.lra</groupId>
+            <artifactId>microprofile-lra-api</artifactId>
+            <version>${version.microprofile.lra}</version>
+        </dependency>
+```
+
+The spec implementation of the LRA annotations is provided by the use of JAX-RS filters which
+are activated by including the following dependency:
+
+```
+        <dependency>
+            <groupId>org.jboss.narayana.rts</groupId>
+            <artifactId>lra-filters</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+```
+
+Start the coordinator as [explained previously](#running-an-external-lra-coordinator) on port 8080:
+
+> java -Dswarm.http.port=8080 -Dswarm.transactions.object-store-path=../txlogs -jar lra-coordinator/target/lra-coordinator-swarm.jar
+
+Start the service on port 8082 (using the swarm.http.port system property) and tell the service which
+port to use for the coordinator (using the lra.http.port system property):
+
+> java -Dswarm.http.port=8082 -Dlra.http.port=8080 -jar cdi-participant/target/lra-participant-example-swarm.jar
+
+Notice this time you did not need to specify the coordinator log directory because the coordinator
+is now running separately from the service.
+
+Test the service (running on port 8082):
+
+> curl -X PUT -I http://localhost:8082/cdi
+
+Verify that service was part of the LRA by either looking at the service console or by asking
+the service if it was notified when the LRA was completing:
+
+> curl http://localhost:8082/cdi
+
+Recovery can be tested in the same way as before:
+
+> curl -X PUT -I http://localhost:8082/cdi?fault=haltcdiduring
+
+Restart the service:
+
+> java -Dswarm.http.port=8082 -Dlra.http.port=8080 -jar cdi-participant/target/lra-participant-example-swarm.jar
+
+When it is ready either wait for recovery or manually trigger a recovery scan (via the
+coordinator running on port 8080):
+
+> curl http://localhost:8080/lra-recovery-coordinator/recovery
+
+Validate the service was asked to complete by either looking at the service console or by running
+the query:
+
+> curl  http://localhost:8082/cdi
+
+Kill the service in preparation for the next quickstart.
+Either manually terminate the coordinator or leave it running ready for the
+[api-participant quickstart](#running-the-api-participant-example).
+
+Remark: if the coordinator fails before the end phase begins then they will be reported by
+a recovery scan but must be completed manually.
+
+## Running the api-participant example
+
+This example is similar to the cdi-participant but instead of using CDI annotations to control
+LRA's and to control participation in the LRA it uses the Java LRA API's. If you replace
+occurences of `cdi` with `api`then the commands for this example should be the same.
+
+Start the coordinator as [explained previously](#running-an-external-lra-coordinator) on port 8080:
+
+> java -Dswarm.http.port=8080 -Dswarm.transactions.object-store-path=../txlogs -jar lra-coordinator/target/lra-coordinator-swarm.jar
+
+Start the service on port 8082 (using the swarm.http.port system property) and tell the service which
+port to use for the coordinator (using the lra.http.port system property):
+
+> java -Dswarm.http.port=8082 -Dlra.http.port=8080 -jar api-participant/target/lra-participant-example-swarm.jar
+
+Notice this time you did not need to specify the coordinator log directory because the coordinator
+is now running separately from the service.
+
+Test the service (running on port 8082):
+
+> curl -X PUT -I http://localhost:8082/api
+
+Verify that service was part of the LRA by either looking at the service console or by asking
+the service if it was notified when the LRA was completing:
+
+> curl http://localhost:8082/api
+
+Recovery can be tested in the same way as before:
+
+> curl -X PUT -I http://localhost:8082/api?fault=haltapiduring
+
+Restart the service:
+
+> java -Dswarm.http.port=8082 -Dlra.http.port=8080 -jar api-participant/target/lra-participant-example-swarm.jar
+
+When it is ready either wait for recovery or manually trigger a recovery scan (via the
+coordinator running on port 8080):
+
+> curl http://localhost:8080/lra-recovery-coordinator/recovery
+
+Validate the service was asked to complete by either looking at the service console or by running
+the query:
+
+> curl  http://localhost:8082/api
+
+Kill both the service and the coordinator in preparation for the next quickstart.
+
+## Running the api-participant-with-coordinator example
+
+Start the service with an embedded coordinator on port 8080:
+
+> java -Dswarm.http.port=8080 -Dlra.http.port=8080 -Dswarm.transactions.object-store-path=../txlogs -jar api-participant-with-coordinator/target/lra-participant-example-swarm.jar
+
+Issue a request that performs an action in the context of an LRA:
+
+> curl -X PUT -I http://localhost:8080/api
+
+Check that the service was asked to complete:
+
+> curl http://localhost:8080/api
+
+Now test recovery by telling the service to halt:
+
+> curl -X PUT -I http://localhost:8080/api?fault=haltapiduring
+
+Restart the service
+
+> java -Dswarm.http.port=8080 -Dlra.http.port=8080 -Dswarm.transactions.object-store-path=../txlogs -jar api-participant-with-coordinator/target/lra-participant-example-swarm.jar
+
+and either wait for recovery or trigger an immediate recovery scan:
+
+> curl http://localhost:8080/lra-recovery-coordinator/recovery
+
+When recovery is complete the service should have been asked to complete. You can verify that
+by either looking at the console or by asking the service if it was asked to complete:
+
+> curl  http://localhost:8080/api
+
+## Running the mixed-participant-with-coordinator example
+
+This quickstart is similar to the
+[api-participant-with-coordinator](#running-the-api-participant-with-coordinator-example).
+Simply replace occurences of `api` with `mixed`. The example shows a service which starts an
+LRA and then invokes the CDI and API based examples using JAX-RS calls in the context of the same
+LRA.

--- a/rts/lra-examples/api-participant-with-coordinator/README.md
+++ b/rts/lra-examples/api-participant-with-coordinator/README.md
@@ -1,0 +1,13 @@
+# MicroProfile LRA API Participant With LRA Coordinator Example
+
+[MicroProfile LRA](https://github.com/eclipse/microprofile-lra) is a specification of an API that
+enables loosely coupled services to coordinate long running activities in such a way as to
+guarantee a globally consistent outcome without the need to take long duration locks on data.
+
+To run the example under Unix based OS's run the maven build lifecycle verify phase:
+
+> mvn verify
+
+To run the example manually with a description of how it works please refer to
+[the description in the lra-examples README](../README.md#running-the-api-participant-with-coordinator-example)
+

--- a/rts/lra-examples/api-participant-with-coordinator/pom.xml
+++ b/rts/lra-examples/api-participant-with-coordinator/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jboss.narayana.quickstart.rts.lra</groupId>
+    <version>5.9.1.Final-SNAPSHOT</version>
+    <artifactId>examples-microprofile-lra-api-participant-with-coordinator</artifactId>
+
+    <name>WildFly Thorntail Examples: Microprofile LRA Participant via API with Coordinator</name>
+    <description>WildFly Thorntail Examples: Microprofile LRA participant using the client API with embedded coordinator</description>
+
+    <packaging>war</packaging>
+
+    <properties>
+        <maven.test.skip>true</maven.test.skip>
+        <swarm.debug.port>5005</swarm.debug.port>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <version.wildfly-swarm>2017.8.1</version.wildfly-swarm>
+        <version.microprofile.lra>1.0-SNAPSHOT</version.microprofile.lra>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>jboss-public-repository-group</id>
+            <name>JBoss Public Maven Repository Group</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <build>
+        <finalName>lra-participant-example</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.swarm</groupId>
+                <artifactId>wildfly-swarm-plugin</artifactId>
+                <version>${version.wildfly-swarm}</version>
+                <configuration>
+                    <debugPort>${swarm.debug.port}</debugPort>
+                    <properties>
+                        <swarm.http.port>8082</swarm.http.port>
+                        <swarm.debug.port>${swarm.debug.port}</swarm.debug.port>
+                        <swarm.transactions.node-identifier>2</swarm.transactions.node-identifier>
+                    </properties>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.narayana.quickstart.rts.lra</groupId>
+            <artifactId>examples-microprofile-lra-api-participant</artifactId>
+            <version>${project.version}</version>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.narayana.rts</groupId>
+            <artifactId>lra-coordinator</artifactId>
+            <version>${project.version}</version>
+            <type>war</type>
+        </dependency>
+    </dependencies>
+    <profiles>
+        <profile>
+            <id>unix</id>
+            <activation>
+                <os>
+                    <family>unix</family>
+                </os>
+                <property>
+                    <name>!skipTests</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>Run Quickstart</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>bash</executable>
+                                    <commandlineArgs>${basedir}/../run.sh</commandlineArgs>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/rts/lra-examples/api-participant/README.md
+++ b/rts/lra-examples/api-participant/README.md
@@ -1,0 +1,13 @@
+# MicroProfile LRA API Participant Example
+
+[MicroProfile LRA](https://github.com/eclipse/microprofile-lra) is a specification of an API that
+enables loosely coupled services to coordinate long running activities in such a way as to
+guarantee a globally consistent outcome without the need to take long duration locks on data.
+
+To run the example under Unix based OS's run the maven build lifecycle verify phase:
+
+> mvn verify
+
+To run the example manually with a description of how it works please refer to
+[the description in the lra-examples README](../README.md#running-the-api-participant-example)
+

--- a/rts/lra-examples/api-participant/pom.xml
+++ b/rts/lra-examples/api-participant/pom.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jboss.narayana.quickstart.rts.lra</groupId>
+    <version>5.9.1.Final-SNAPSHOT</version>
+    <artifactId>examples-microprofile-lra-api-participant</artifactId>
+
+    <name>WildFly Thorntail Examples: Microprofile LRA API Participant</name>
+    <description>WildFly Thorntail Examples: Microprofile LRA Participant using API</description>
+
+    <packaging>war</packaging>
+
+    <properties>
+        <maven.test.skip>true</maven.test.skip>
+        <swarm.debug.port>5005</swarm.debug.port>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <version.wildfly-swarm>2017.8.1</version.wildfly-swarm>
+        <version.microprofile.lra>1.0-SNAPSHOT</version.microprofile.lra>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>jboss-public-repository-group</id>
+            <name>JBoss Public Maven Repository Group</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <build>
+        <finalName>lra-participant-example</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.swarm</groupId>
+                <artifactId>wildfly-swarm-plugin</artifactId>
+                <version>${version.wildfly-swarm}</version>
+                <configuration>
+                    <debugPort>${swarm.debug.port}</debugPort>
+                    <properties>
+                        <swarm.http.port>8082</swarm.http.port>
+                        <swarm.debug.port>${swarm.debug.port}</swarm.debug.port>
+                        <swarm.transactions.node-identifier>2</swarm.transactions.node-identifier>
+                    </properties>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <!-- the microprofile-lra thorntail fraction isn't ready yet
+                <dependency>
+                    <groupId>org.wildfly.swarm</groupId>
+                    <artifactId>microprofile-lra</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+        -->
+        <!-- MP LRA provides an API for participants to join an LRA
+        -->
+        <dependency>
+            <groupId>org.jboss.narayana.rts</groupId>
+            <artifactId>lra-proxy-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- MP LRA proides an API for clients to begin and end LRAs
+        -->
+        <dependency>
+            <groupId>org.jboss.narayana.rts</groupId>
+            <artifactId>lra-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- JAX-RS -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+            <version>1.0.0.Final</version>
+        </dependency>
+
+        <!-- JBoss logging -->
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <version>3.1.0.GA</version>
+        </dependency>
+    </dependencies>
+    <profiles>
+        <profile>
+            <id>unix</id>
+            <activation>
+                <os>
+                    <family>unix</family>
+                </os>
+                <property>
+                    <name>!skipTests</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>Run Quickstart</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>bash</executable>
+                                    <commandlineArgs>${basedir}/../run.sh</commandlineArgs>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/rts/lra-examples/api-participant/src/main/java/io/narayana/rts/lra/JaxRsActivator.java
+++ b/rts/lra-examples/api-participant/src/main/java/io/narayana/rts/lra/JaxRsActivator.java
@@ -1,0 +1,8 @@
+package io.narayana.rts.lra;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class JaxRsActivator extends Application {
+}

--- a/rts/lra-examples/api-participant/src/main/java/io/narayana/rts/lra/ParticipantDeserializer.java
+++ b/rts/lra-examples/api-participant/src/main/java/io/narayana/rts/lra/ParticipantDeserializer.java
@@ -1,0 +1,21 @@
+package io.narayana.rts.lra;
+
+import org.eclipse.microprofile.lra.participant.LRAParticipant;
+import org.eclipse.microprofile.lra.participant.LRAParticipantDeserializer;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.net.URL;
+import java.util.Base64;
+
+public class ParticipantDeserializer implements LRAParticipantDeserializer {
+    @Override
+    public LRAParticipant deserialize(URL lraId, byte[] data) {
+        try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(data))) {
+            return (LRAParticipant) ois.readObject();
+        } catch (final IOException | ClassNotFoundException e) {
+            return null;
+        }
+    }
+}

--- a/rts/lra-examples/api-participant/src/main/java/io/narayana/rts/lra/ProxyBasedResource.java
+++ b/rts/lra-examples/api-participant/src/main/java/io/narayana/rts/lra/ProxyBasedResource.java
@@ -1,0 +1,108 @@
+package io.narayana.rts.lra;
+
+import org.eclipse.microprofile.lra.annotation.CompensatorStatus;
+import org.eclipse.microprofile.lra.client.LRAClient;
+import org.eclipse.microprofile.lra.participant.JoinLRAException;
+import org.eclipse.microprofile.lra.participant.LRAManagement;
+import org.eclipse.microprofile.lra.participant.LRAParticipant;
+import org.eclipse.microprofile.lra.participant.TerminationException;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.net.URL;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+@Path("/")
+@ApplicationScoped
+public class ProxyBasedResource implements LRAParticipant, Serializable {
+
+    @Inject
+    private StateHolder stats;
+
+    @Inject
+    private LRAClient lraClient;
+
+    @Inject
+    private LRAManagement lraManagement;
+
+    @Inject
+    private ParticipantDeserializer participantDeserializer;
+
+    @PostConstruct
+    private void postConstruct() {
+        lraManagement.registerDeserializer(participantDeserializer);
+    }
+
+    @PreDestroy
+    private void preDestroy() {
+        lraManagement.unregisterDeserializer(participantDeserializer);
+    }
+
+    private void writeObject(ObjectOutputStream out) throws IOException {
+    }
+
+    private void readObject(ObjectInputStream in) throws IOException,ClassNotFoundException {
+    }
+
+    @Path("/api")
+    @PUT
+    public String doInTransaction(@QueryParam("fault") String fault) throws JoinLRAException {
+        getStateHolder().setFault(fault);
+        URL lraId = lraClient.startLRA("No CDI based client", 0L, TimeUnit.MILLISECONDS);
+
+        getStateHolder().injectFault(StateHolder.FaultTarget.API, StateHolder.FaultWhen.BEFORE);
+        lraManagement.joinLRA(this, lraId, 0L, TimeUnit.SECONDS);
+
+        // do something interesting
+        lraClient.closeLRA(lraId);
+        getStateHolder().injectFault(StateHolder.FaultTarget.API, StateHolder.FaultWhen.AFTER);
+
+        return getStateHolder().toString();
+    }
+
+    @Path("/api")
+    @GET
+    @Produces("text/plain")
+    public String getStats() {
+        return getStateHolder().toString();
+    }
+
+    @Override
+    public Future<Void> completeWork(URL lraId) throws NotFoundException, TerminationException {
+        getStateHolder().update(StateHolder.FaultTarget.API, CompensatorStatus.Completed);
+        getStateHolder().injectFault(StateHolder.FaultTarget.API, StateHolder.FaultWhen.DURING);
+
+        return null;
+    }
+
+    @Override
+    public Future<Void> compensateWork(URL lraId) throws NotFoundException, TerminationException {
+        getStateHolder().update(StateHolder.FaultTarget.API, CompensatorStatus.Completed);
+        getStateHolder().injectFault(StateHolder.FaultTarget.API, StateHolder.FaultWhen.DURING);
+
+        return null;
+    }
+
+    private StateHolder getStateHolder() {
+        // we do not use the injected StateHolder since in recovery situations CDI may not have
+        // initialised this bean and doing it manually via
+        // CDI.current().select(ProxyBasedResource.class).get() is no good either
+        return stateHolder;
+    }
+
+    private static StateHolder stateHolder = new StateHolder();
+}

--- a/rts/lra-examples/api-participant/src/main/java/io/narayana/rts/lra/StateHolder.java
+++ b/rts/lra-examples/api-participant/src/main/java/io/narayana/rts/lra/StateHolder.java
@@ -1,0 +1,101 @@
+package io.narayana.rts.lra;
+
+import org.eclipse.microprofile.lra.annotation.CompensatorStatus;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.io.Serializable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.narayana.rts.lra.StateHolder.FaultTarget.API;
+import static io.narayana.rts.lra.StateHolder.FaultTarget.CDI;
+import static io.narayana.rts.lra.StateHolder.FaultTarget.MIXED;
+import static io.narayana.rts.lra.StateHolder.FaultTarget.NONE;
+import static io.narayana.rts.lra.StateHolder.FaultType.HALT;
+import static io.narayana.rts.lra.StateHolder.FaultWhen.AFTER;
+import static io.narayana.rts.lra.StateHolder.FaultWhen.BEFORE;
+
+@ApplicationScoped
+public class StateHolder implements Serializable {
+    private AtomicInteger completedCount = new AtomicInteger(0);
+    private AtomicInteger compensatedCount = new AtomicInteger(0);
+
+    private FaultTarget target = FaultTarget.NONE;
+    private FaultType type = FaultType.NONE;
+    private FaultWhen when = FaultWhen.DURING;
+
+    enum FaultTarget {CDI, API, MIXED, NONE};
+    enum FaultType {HALT, NONE};
+    enum FaultWhen { // when to inject a fault
+        NOW, // immediately
+        BEFORE, // before the end phase
+        DURING, // during the end phase
+        AFTER // after the end phase
+    };
+
+    public int getCompletedCount() {
+        return completedCount.get();
+    }
+
+    public int getCompensatedCount() {
+        return compensatedCount.get();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%d completed and %d compensated", getCompletedCount(), getCompensatedCount());
+    }
+
+    public void update(FaultTarget target, CompensatorStatus status) {
+        if (status == null) {
+            injectFault(target, BEFORE);
+        }
+
+        if (status == CompensatorStatus.Completed) {
+            completedCount.incrementAndGet();
+            System.out.printf("%d completions%n", completedCount.get());
+        } else if (status == CompensatorStatus.Compensated) {
+            System.out.printf("%d compensations%n", compensatedCount.get());
+            compensatedCount.incrementAndGet();
+        }
+    }
+
+    void injectFault(FaultTarget target, FaultWhen when) {
+        if (this.target == target && this.when == when) {
+            System.out.printf("injecting fault type %s ...%n", type);
+
+            if (type == HALT) {
+                Runtime.getRuntime().halt(1);
+            }
+        }
+    }
+
+    void setFault(String fault) {
+        if (fault == null) {
+            fault = "";
+        }
+
+        fault = fault.toLowerCase();
+
+        if (fault.contains("cdi")) {
+            target = CDI;
+        } else if (fault.contains("api")) {
+            target = API;
+        } else if (fault.contains("mixed")) {
+            target = MIXED;
+        } else {
+            target = NONE;
+        }
+
+        if (fault.contains("halt")) {
+            type = HALT;
+        }
+
+        if (fault.contains("before")) {
+            when = BEFORE;
+        } else if (fault.contains("during")) {
+            when = FaultWhen.DURING;
+        } else if (fault.contains("after")) {
+            when = AFTER;
+        }
+    }
+}

--- a/rts/lra-examples/api-participant/src/main/resources/META-INF/beans.xml
+++ b/rts/lra-examples/api-participant/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,6 @@
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee 
+		http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       bean-discovery-mode="all">
+</beans>

--- a/rts/lra-examples/cdi-participant-with-coordinator/README.md
+++ b/rts/lra-examples/cdi-participant-with-coordinator/README.md
@@ -1,0 +1,13 @@
+# MicroProfile LRA CDI Participant With Coordinator Example
+
+[MicroProfile LRA](https://github.com/eclipse/microprofile-lra) is a specification of an API that
+enables loosely coupled services to coordinate long running activities in such a way as to
+guarantee a globally consistent outcome without the need to take long duration locks on data.
+
+To run the example under Unix based OS's run the maven build lifecycle verify phase:
+
+> mvn verify
+
+To run the example manually with a description of how it works please refer to
+[the description in the lra-examples README](../README.md#running-the-cdi-participant-with-coordinator-example
+

--- a/rts/lra-examples/cdi-participant-with-coordinator/pom.xml
+++ b/rts/lra-examples/cdi-participant-with-coordinator/pom.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jboss.narayana.quickstart.rts.lra</groupId>
+    <version>5.9.1.Final-SNAPSHOT</version>
+    <artifactId>examples-microprofile-lra-cdi-participant-with-coordinator</artifactId>
+
+    <name>WildFly Thorntail Examples: Microprofile LRA CDI Participant with Coordinator</name>
+    <description>WildFly Thorntail Examples: Microprofile LRA CDI participant using annotations with coordinator</description>
+
+    <packaging>war</packaging>
+
+    <properties>
+        <maven.test.skip>true</maven.test.skip>
+        <swarm.debug.port>5005</swarm.debug.port>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <version.wildfly-swarm>2017.8.1</version.wildfly-swarm>
+        <version.microprofile.lra>1.0-SNAPSHOT</version.microprofile.lra>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>jboss-public-repository-group</id>
+            <name>JBoss Public Maven Repository Group</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <build>
+        <finalName>lra-participant-example</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.swarm</groupId>
+                <artifactId>wildfly-swarm-plugin</artifactId>
+                <version>${version.wildfly-swarm}</version>
+                <configuration>
+                    <debugPort>${swarm.debug.port}</debugPort>
+                    <properties>
+                        <swarm.http.port>8082</swarm.http.port>
+                        <swarm.debug.port>${swarm.debug.port}</swarm.debug.port>
+                        <swarm.transactions.node-identifier>2</swarm.transactions.node-identifier>
+                    </properties>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.narayana.quickstart.rts.lra</groupId>
+            <artifactId>examples-microprofile-lra-cdi-participant</artifactId>
+            <version>${project.version}</version>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.narayana.rts</groupId>
+            <artifactId>lra-coordinator</artifactId>
+            <version>${project.version}</version>
+            <type>war</type>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>unix</id>
+            <activation>
+                <os>
+                    <family>unix</family>
+                </os>
+                <property>
+                    <name>!skipTests</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>Run Quickstart</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>bash</executable>
+                                    <commandlineArgs>${basedir}/../run.sh</commandlineArgs>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/rts/lra-examples/cdi-participant-with-coordinator/run.sh
+++ b/rts/lra-examples/cdi-participant-with-coordinator/run.sh
@@ -1,0 +1,80 @@
+# ALLOW JOBS TO BE BACKGROUNDED
+set -m
+
+swarmjar="lra-participant-example-swarm.jar"
+txlogdir="../txlogs"
+txlogprop="swarm.transactions.object-store-path"
+qsdir="$PWD"
+service_port=8082
+coord_port=8082
+
+usage() { echo -e "$1\nUsage: $0 [-s <service port>] [-c <coordinator port>] [-d <directory>]" 1>&2; exit 1; }
+
+while getopts ":s:c:d:" opt; do
+    case "${opt}" in
+        c) coord_port=${OPTARG};
+           [[ $coord_port =~ ^[0-9]+$ ]] || usage "${OPTARG} is not a valid port" ;;
+        s) service_port=${OPTARG};
+           [[ $service_port =~ ^[0-9]+$ ]] || usage "${OPTARG} is not a valid port" ;;
+        d) qsdir=${OPTARG} ;;
+        *) usage ;;
+    esac
+done
+shift $((OPTIND-1))
+
+[[ -d "$qsdir" ]] || usage "$qsdir is not a valid directory"
+cd $qsdir
+qsname=$(basename "$PWD")
+
+arr=(${qsname//-/ })
+svctype=${arr[0]}
+last=${arr[${#arr[@]} - 1]}
+
+[[ "$svctype" =~ ^(cdi|api|mixed)$ ]] || usage "quickstart directory must start with {cdi|api|mixed}"
+
+function killpid {
+  kill $2
+  test $? || echo "===== could not kill $1"
+}
+
+function test_service {
+  curl -X PUT -I http://localhost:${service_port}/${svctype} || echo ===== failed
+  sleep 1
+  if [ "$(curl http://localhost:${service_port}/${svctype})" == "$1" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+echo "===== Running qickstart $qsname in directory $PWD"
+
+if [[ "$last" != "coordinator" ]]; then
+  echo "===== starting external coordinator on port ${coord_port}"
+  java -D${txlogprop}=${txlogdir} -Dswarm.http.port=${coord_port} -jar ../lra-coordinator/target/lra-coordinator-swarm.jar &
+  coord_pid=$!
+  sleep 10
+else
+  coord_port=${service_port} # the coordinator is running in-VM with the service
+fi
+
+echo "===== starting service on port ${service_port}"
+java -Dswarm.http.port=${service_port} -Dlra.http.port=${coord_port} -jar target/${swarmjar} &
+echo "===== Running qickstart $qsname in directory $PWD"
+service_pid=$!
+sleep 10
+
+echo "===== testing service"
+if [ $svctype = "mixed" ]; then
+  test_service "2 completed and 0 compensated"
+else
+  test_service "1 completed and 0 compensated"
+fi
+res=$?
+
+killpid "service" $service_pid 
+[[ -z ${coord_pid+x} ]] || killpid "coordinator" $coord_pid
+
+echo "===== test $qsname completed with status $res"
+
+exit $res

--- a/rts/lra-examples/cdi-participant/README.md
+++ b/rts/lra-examples/cdi-participant/README.md
@@ -1,0 +1,13 @@
+# MicroProfile LRA CDI Participant Example
+
+[MicroProfile LRA](https://github.com/eclipse/microprofile-lra) is a specification of an API that
+enables loosely coupled services to coordinate long running activities in such a way as to
+guarantee a globally consistent outcome without the need to take long duration locks on data.
+
+To run the example under Unix based OS's run the maven build lifecycle verify phase:
+
+> mvn verify
+
+To run the example manually with a description of how it works please refer to
+[the description in the lra-examples README](../README.md#running-the-cdi-participant-example)
+

--- a/rts/lra-examples/cdi-participant/pom.xml
+++ b/rts/lra-examples/cdi-participant/pom.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jboss.narayana.quickstart.rts.lra</groupId>
+    <version>5.9.1.Final-SNAPSHOT</version>
+    <artifactId>examples-microprofile-lra-cdi-participant</artifactId>
+
+    <name>WildFly Thorntail Examples: Microprofile LRA CDI Participant</name>
+    <description>WildFly Thorntail Examples: Microprofile LRA CDI participant using annotations</description>
+
+    <packaging>war</packaging>
+
+    <properties>
+        <maven.test.skip>true</maven.test.skip>
+        <swarm.debug.port>5005</swarm.debug.port>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <version.wildfly-swarm>2017.8.1</version.wildfly-swarm>
+        <version.microprofile.lra>1.0-SNAPSHOT</version.microprofile.lra>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>jboss-public-repository-group</id>
+            <name>JBoss Public Maven Repository Group</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <build>
+        <finalName>lra-participant-example</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.swarm</groupId>
+                <artifactId>wildfly-swarm-plugin</artifactId>
+                <version>${version.wildfly-swarm}</version>
+                <configuration>
+                    <debugPort>${swarm.debug.port}</debugPort>
+                    <properties>
+                        <swarm.http.port>8082</swarm.http.port>
+                        <swarm.debug.port>${swarm.debug.port}</swarm.debug.port>
+                        <swarm.transactions.node-identifier>2</swarm.transactions.node-identifier>
+                    </properties>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <!-- the microprofile-lra thorntail fraction isn't ready yet
+                <dependency>
+                    <groupId>org.wildfly.swarm</groupId>
+                    <artifactId>microprofile-lra</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+        -->
+
+        <!-- MP LRA CDI support relies on JAX-RS filters for
+             starting LRAs and for enlisting resources in LRAs
+        -->
+        <dependency>
+            <groupId>org.jboss.narayana.rts</groupId>
+            <artifactId>lra-filters</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- MP LRA CDI support defines annotations for controlling the lifecycle
+             of LRAs and for controlling participation in an LRA
+             -->
+        <dependency>
+            <groupId>io.narayana.microprofile.lra</groupId>
+            <artifactId>microprofile-lra-api</artifactId>
+            <version>${version.microprofile.lra}</version>
+        </dependency>
+
+        <!-- JAX-RS -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+            <version>1.0.0.Final</version>
+        </dependency>
+
+        <!-- JBoss logging -->
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <version>3.1.0.GA</version>
+        </dependency>
+    </dependencies>
+    <profiles>
+        <profile>
+            <id>unix</id>
+            <activation>
+                <os>
+                    <family>unix</family>
+                </os>
+                <property>
+                    <name>!skipTests</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>Run Quickstart</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>bash</executable>
+                                    <commandlineArgs>${basedir}/../run.sh</commandlineArgs>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/rts/lra-examples/cdi-participant/src/main/java/io/narayana/rts/lra/CdiBasedResource.java
+++ b/rts/lra-examples/cdi-participant/src/main/java/io/narayana/rts/lra/CdiBasedResource.java
@@ -1,0 +1,74 @@
+package io.narayana.rts.lra;
+
+import org.eclipse.microprofile.lra.annotation.Compensate;
+import org.eclipse.microprofile.lra.annotation.CompensatorStatus;
+import org.eclipse.microprofile.lra.annotation.Complete;
+import org.eclipse.microprofile.lra.annotation.LRA;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import static org.eclipse.microprofile.lra.client.LRAClient.LRA_HTTP_HEADER;
+import static org.eclipse.microprofile.lra.client.LRAClient.LRA_HTTP_RECOVERY_HEADER;
+
+/**
+ * for testing {@link org.eclipse.microprofile.lra.annotation.LRA}
+ */
+@Path("/")
+@ApplicationScoped
+public class CdiBasedResource {
+
+    @Inject
+    private StateHolder stats;
+
+    @LRA(LRA.Type.REQUIRED)
+    @Path("/cdi")
+    @PUT
+    public void doInTransaction(@DefaultValue("") @QueryParam("fault") String fault,
+                                  @HeaderParam(LRA_HTTP_RECOVERY_HEADER) String rcvId,
+                                  @HeaderParam(LRA_HTTP_HEADER) String lraId) {
+        stats.setFault(fault);
+        stats.injectFault(StateHolder.FaultTarget.CDI, StateHolder.FaultWhen.BEFORE);
+        // do something interesting
+    }
+
+    @Path("/cdi")
+    @GET
+    public String getStats() {
+        return stats.toString();
+    }
+
+    @PUT
+    @Path("/complete")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Complete
+    public Response completeWork(@HeaderParam(LRA_HTTP_HEADER) String lraId, String userData)
+            throws NotFoundException {
+        stats.update(StateHolder.FaultTarget.CDI, CompensatorStatus.Completed);
+        stats.injectFault(StateHolder.FaultTarget.CDI, StateHolder.FaultWhen.DURING);
+
+        return Response.ok().build();
+    }
+
+    @PUT
+    @Path("/compensate")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Compensate
+    public Response compensateWork(@HeaderParam(LRA_HTTP_HEADER) String lraId, String userData)
+            throws NotFoundException {
+        stats.update(StateHolder.FaultTarget.CDI, CompensatorStatus.Compensated);
+        stats.injectFault(StateHolder.FaultTarget.CDI, StateHolder.FaultWhen.DURING);
+
+        return Response.ok().build();
+    }
+}

--- a/rts/lra-examples/cdi-participant/src/main/java/io/narayana/rts/lra/JaxRsActivator.java
+++ b/rts/lra-examples/cdi-participant/src/main/java/io/narayana/rts/lra/JaxRsActivator.java
@@ -1,0 +1,8 @@
+package io.narayana.rts.lra;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class JaxRsActivator extends Application {
+}

--- a/rts/lra-examples/cdi-participant/src/main/java/io/narayana/rts/lra/StateHolder.java
+++ b/rts/lra-examples/cdi-participant/src/main/java/io/narayana/rts/lra/StateHolder.java
@@ -1,0 +1,101 @@
+package io.narayana.rts.lra;
+
+import org.eclipse.microprofile.lra.annotation.CompensatorStatus;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.io.Serializable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.narayana.rts.lra.StateHolder.FaultTarget.API;
+import static io.narayana.rts.lra.StateHolder.FaultTarget.CDI;
+import static io.narayana.rts.lra.StateHolder.FaultTarget.MIXED;
+import static io.narayana.rts.lra.StateHolder.FaultTarget.NONE;
+import static io.narayana.rts.lra.StateHolder.FaultType.HALT;
+import static io.narayana.rts.lra.StateHolder.FaultWhen.AFTER;
+import static io.narayana.rts.lra.StateHolder.FaultWhen.BEFORE;
+
+@ApplicationScoped
+public class StateHolder implements Serializable {
+    private AtomicInteger completedCount = new AtomicInteger(0);
+    private AtomicInteger compensatedCount = new AtomicInteger(0);
+
+    private FaultTarget target = FaultTarget.NONE;
+    private FaultType type = FaultType.NONE;
+    private FaultWhen when = FaultWhen.DURING;
+
+    enum FaultTarget {CDI, API, MIXED, NONE};
+    enum FaultType {HALT, NONE};
+    enum FaultWhen { // when to inject a fault
+        NOW, // immediately
+        BEFORE, // before the end phase
+        DURING, // during the end phase
+        AFTER // after the end phase
+    };
+
+    public int getCompletedCount() {
+        return completedCount.get();
+    }
+
+    public int getCompensatedCount() {
+        return compensatedCount.get();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%d completed and %d compensated", getCompletedCount(), getCompensatedCount());
+    }
+
+    public void update(FaultTarget target, CompensatorStatus status) {
+        if (status == null) {
+            injectFault(target, BEFORE);
+        }
+
+        if (status == CompensatorStatus.Completed) {
+            completedCount.incrementAndGet();
+            System.out.printf("%d completions%n", completedCount.get());
+        } else if (status == CompensatorStatus.Compensated) {
+            System.out.printf("%d compensations%n", compensatedCount.get());
+            compensatedCount.incrementAndGet();
+        }
+    }
+
+    void injectFault(FaultTarget target, FaultWhen when) {
+        if (this.target == target && this.when == when) {
+            System.out.printf("injecting fault type %s ...%n", type);
+
+            if (type == HALT) {
+                Runtime.getRuntime().halt(1);
+            }
+        }
+    }
+
+    void setFault(String fault) {
+        if (fault == null) {
+            fault = "";
+        }
+
+        fault = fault.toLowerCase();
+
+        if (fault.contains("cdi")) {
+            target = CDI;
+        } else if (fault.contains("api")) {
+            target = API;
+        } else if (fault.contains("mixed")) {
+            target = MIXED;
+        } else {
+            target = NONE;
+        }
+
+        if (fault.contains("halt")) {
+            type = HALT;
+        }
+
+        if (fault.contains("before")) {
+            when = BEFORE;
+        } else if (fault.contains("during")) {
+            when = FaultWhen.DURING;
+        } else if (fault.contains("after")) {
+            when = AFTER;
+        }
+    }
+}

--- a/rts/lra-examples/cdi-participant/src/main/resources/META-INF/beans.xml
+++ b/rts/lra-examples/cdi-participant/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,6 @@
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee 
+		http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       bean-discovery-mode="all">
+</beans>

--- a/rts/lra-examples/lra-coordinator/README.md
+++ b/rts/lra-examples/lra-coordinator/README.md
@@ -1,0 +1,11 @@
+# MicroProfile LRA API Participant Example
+
+[MicroProfile LRA](https://github.com/eclipse/microprofile-lra) is a specification of an API that
+enables loosely coupled services to coordinate long running activities in such a way as to
+guarantee a globally consistent outcome without the need to take long duration locks on data.
+
+This module contains a swarm jar for running a standalone LRA coordinator.
+
+For instructions for how to run it please refer to
+[the description in the lra-examples README](../README.md#running-an-external-lra-coordinator)
+

--- a/rts/lra-examples/lra-coordinator/pom.xml
+++ b/rts/lra-examples/lra-coordinator/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jboss.narayana.quickstart.rts.lra</groupId>
+    <version>5.9.1.Final-SNAPSHOT</version>
+    <artifactId>examples-microprofile-lra-coordinator</artifactId>
+
+    <name>WildFly Thorntail Examples: LRA Coordinator</name>
+    <description>WildFly Thorntail Examples: LRA Coordinator</description>
+
+    <packaging>war</packaging>
+
+    <properties>
+        <maven.test.skip>true</maven.test.skip>
+        <swarm.debug.port>5006</swarm.debug.port>
+        <swarm.http.port>8080</swarm.http.port>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <version.wildfly-swarm>2018.5.0</version.wildfly-swarm>
+        <version.microprofile.lra>1.0-SNAPSHOT</version.microprofile.lra>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>jboss-public-repository-group</id>
+            <name>JBoss Public Maven Repository Group</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <build>
+        <finalName>lra-coordinator</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.swarm</groupId>
+                <artifactId>wildfly-swarm-plugin</artifactId>
+                <version>${version.wildfly-swarm}</version>
+                <configuration>
+                    <debugPort>${swarm.debug.port}</debugPort>
+                    <properties>
+                        <swarm.http.port>8080</swarm.http.port>
+                        <swarm.debug.port>${swarm.debug.port}</swarm.debug.port>
+                        <swarm.transactions.node-identifier>2</swarm.transactions.node-identifier>
+                    </properties>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.narayana.rts</groupId>
+            <artifactId>lra-coordinator</artifactId>
+            <version>${project.version}</version>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>jaxrs</artifactId>
+            <version>${version.wildfly-swarm}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>cdi</artifactId>
+            <version>${version.wildfly-swarm}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/rts/lra-examples/mixed-participant-with-coordinator/README.md
+++ b/rts/lra-examples/mixed-participant-with-coordinator/README.md
@@ -1,0 +1,13 @@
+# MicroProfile LRA Mixed Participant With Coordinator Example
+
+[MicroProfile LRA](https://github.com/eclipse/microprofile-lra) is a specification of an API that
+enables loosely coupled services to coordinate long running activities in such a way as to
+guarantee a globally consistent outcome without the need to take long duration locks on data.
+
+To run the example under Unix based OS's run the maven build lifecycle verify phase:
+
+> mvn verify
+
+To run the example manually with a description of how it works please refer to
+[the description in the lra-examples README](../README.md#running the mixed-participant-with-coordinator example)
+

--- a/rts/lra-examples/mixed-participant-with-coordinator/pom.xml
+++ b/rts/lra-examples/mixed-participant-with-coordinator/pom.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jboss.narayana.quickstart.rts.lra</groupId>
+    <version>5.9.1.Final-SNAPSHOT</version>
+    <artifactId>examples-microprofile-lra-mixed-participant-with-coordinator</artifactId>
+
+    <name>WildFly Thorntail Examples: Microprofile LRA Participants with Coordinator</name>
+    <description>WildFly Thorntail Examples: Microprofile LRA participant mixing cdi and api based JAX-RS resources with an in-VM coordinator</description>
+
+    <packaging>war</packaging>
+
+    <properties>
+        <maven.test.skip>true</maven.test.skip>
+        <swarm.debug.port>5005</swarm.debug.port>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <version.wildfly-swarm>2017.8.1</version.wildfly-swarm>
+        <version.microprofile.lra>1.0-SNAPSHOT</version.microprofile.lra>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>jboss-public-repository-group</id>
+            <name>JBoss Public Maven Repository Group</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <build>
+        <finalName>lra-participant-example</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.swarm</groupId>
+                <artifactId>wildfly-swarm-plugin</artifactId>
+                <version>${version.wildfly-swarm}</version>
+                <configuration>
+                    <debugPort>${swarm.debug.port}</debugPort>
+                    <properties>
+                        <swarm.http.port>8082</swarm.http.port>
+                        <swarm.debug.port>${swarm.debug.port}</swarm.debug.port>
+                        <swarm.transactions.node-identifier>2</swarm.transactions.node-identifier>
+                    </properties>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.narayana.quickstart.rts.lra</groupId>
+            <artifactId>examples-microprofile-lra-cdi-participant</artifactId>
+            <version>${project.version}</version>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.narayana.quickstart.rts.lra</groupId>
+            <artifactId>examples-microprofile-lra-api-participant</artifactId>
+            <version>${project.version}</version>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.narayana.rts</groupId>
+            <artifactId>lra-coordinator</artifactId>
+            <version>${project.version}</version>
+            <type>war</type>
+        </dependency>
+
+        <!-- MP LRA CDI support defines annotations for controlling the lifecycle
+     of LRAs and for controlling participation in an LRA
+     -->
+        <dependency>
+            <groupId>io.narayana.microprofile.lra</groupId>
+            <artifactId>microprofile-lra-api</artifactId>
+            <version>${version.microprofile.lra}</version>
+        </dependency>
+
+        <!-- JAX-RS -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+            <version>1.0.0.Final</version>
+        </dependency>
+    </dependencies>
+<!-- run manually
+    <profiles>
+        <profile>
+            <id>unix</id>
+            <activation>
+                <os>
+                    <family>unix</family>
+                </os>
+                <property>
+                    <name>!skipTests</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>Run Quickstart</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>bash</executable>
+                                    <commandlineArgs>${basedir}/../run.sh</commandlineArgs>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+-->
+</project>

--- a/rts/lra-examples/mixed-participant-with-coordinator/src/main/java/io/narayana/rts/lra/MixedResource.java
+++ b/rts/lra-examples/mixed-participant-with-coordinator/src/main/java/io/narayana/rts/lra/MixedResource.java
@@ -1,0 +1,92 @@
+package io.narayana.rts.lra;
+
+import org.eclipse.microprofile.lra.annotation.LRA;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+
+import static org.eclipse.microprofile.lra.client.LRAClient.LRA_HTTP_HEADER;
+import static org.eclipse.microprofile.lra.client.LRAClient.LRA_HTTP_RECOVERY_HEADER;
+
+/**
+ * for testing {@link org.eclipse.microprofile.lra.annotation.LRA}
+ * in combination with {@link org.eclipse.microprofile.lra.participant.LRAManagement}
+ */
+@Path("/")
+@ApplicationScoped
+public class MixedResource {
+
+    @Inject
+    private StateHolder stats;
+
+    @Context
+    private UriInfo context;
+
+    private static Client msClient;
+    private WebTarget msTarget;
+
+    @PostConstruct
+    private void postConstruct() {
+        int servicePort = Integer.getInteger("swarm.http.port", 8080);
+
+        try {
+            URL microserviceBaseUrl = new URL("http://localhost:" + servicePort);
+
+            // setting up the client
+            msClient = ClientBuilder.newClient();
+
+            msTarget = msClient.target(URI.create(new URL(microserviceBaseUrl, "/").toExternalForm()));
+        } catch (MalformedURLException e) {
+            System.err.printf("WARN: unabled to construct URL: %s%n", e.getMessage());
+        }
+    }
+
+    @LRA(LRA.Type.REQUIRED)
+    @Path("/mixed")
+    @PUT
+    public void doInTransaction(@DefaultValue("") @QueryParam("fault") String fault,
+                                  @HeaderParam(LRA_HTTP_RECOVERY_HEADER) String rcvId,
+                                  @HeaderParam(LRA_HTTP_HEADER) String lraId) throws MalformedURLException {
+        URL lra = new URL(lraId);
+
+        doWork(lra, "/cdi", fault);
+        doWork(lra, "/api", fault);
+    }
+
+    @Path("/mixed")
+    @GET
+    public String getStats() {
+        return stats.toString();
+    }
+
+    private void doWork(URL lraId, String path, String fault) {
+        stats.setFault(fault);
+
+        try (Response response = msTarget.path(path)
+                .queryParam("fault", fault)
+                .request().put(Entity.text(""))) {
+            if (!response.getStatusInfo().getFamily().equals(Response.Status.Family.SUCCESSFUL)) {
+                throw new WebApplicationException(response);
+            }
+        }
+    }
+}

--- a/rts/lra-examples/mixed-participant-with-coordinator/src/main/java/io/narayana/rts/lra/StateHolder.java
+++ b/rts/lra-examples/mixed-participant-with-coordinator/src/main/java/io/narayana/rts/lra/StateHolder.java
@@ -1,0 +1,102 @@
+package io.narayana.rts.lra;
+
+import org.eclipse.microprofile.lra.annotation.CompensatorStatus;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.io.Serializable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.narayana.rts.lra.StateHolder.FaultTarget.API;
+import static io.narayana.rts.lra.StateHolder.FaultTarget.CDI;
+import static io.narayana.rts.lra.StateHolder.FaultTarget.MIXED;
+import static io.narayana.rts.lra.StateHolder.FaultTarget.NONE;
+import static io.narayana.rts.lra.StateHolder.FaultType.HALT;
+import static io.narayana.rts.lra.StateHolder.FaultWhen.AFTER;
+import static io.narayana.rts.lra.StateHolder.FaultWhen.BEFORE;
+import static io.narayana.rts.lra.StateHolder.FaultWhen.NOW;
+
+@ApplicationScoped
+public class StateHolder implements Serializable {
+    private AtomicInteger completedCount = new AtomicInteger(0);
+    private AtomicInteger compensatedCount = new AtomicInteger(0);
+
+    private FaultTarget target = FaultTarget.NONE;
+    private FaultType type = FaultType.NONE;
+    private FaultWhen when = FaultWhen.DURING;
+
+    enum FaultTarget {CDI, API, MIXED, NONE};
+    enum FaultType {HALT, NONE};
+    enum FaultWhen { // when to inject a fault
+        NOW, // immediately
+        BEFORE, // before the end phase
+        DURING, // during the end phase
+        AFTER // after the end phase
+    };
+
+    public int getCompletedCount() {
+        return completedCount.get();
+    }
+
+    public int getCompensatedCount() {
+        return compensatedCount.get();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%d completed and %d compensated", getCompletedCount(), getCompensatedCount());
+    }
+
+    public void update(FaultTarget target, CompensatorStatus status) {
+        if (status == null) {
+            injectFault(target, BEFORE);
+        }
+
+        if (status == CompensatorStatus.Completed) {
+            completedCount.incrementAndGet();
+            System.out.printf("%d completions%n", completedCount.get());
+        } else if (status == CompensatorStatus.Compensated) {
+            System.out.printf("%d compensations%n", compensatedCount.get());
+            compensatedCount.incrementAndGet();
+        }
+    }
+
+    void injectFault(FaultTarget target, FaultWhen when) {
+        if (this.target == target && this.when == when) {
+            System.out.printf("injecting fault type %s ...%n", type);
+
+            if (type == HALT) {
+                Runtime.getRuntime().halt(1);
+            }
+        }
+    }
+
+    void setFault(String fault) {
+        if (fault == null) {
+            fault = "";
+        }
+
+        fault = fault.toLowerCase();
+
+        if (fault.contains("cdi")) {
+            target = CDI;
+        } else if (fault.contains("api")) {
+            target = API;
+        } else if (fault.contains("mixed")) {
+            target = MIXED;
+        } else {
+            target = NONE;
+        }
+
+        if (fault.contains("halt")) {
+            type = HALT;
+        }
+
+        if (fault.contains("before")) {
+            when = BEFORE;
+        } else if (fault.contains("during")) {
+            when = FaultWhen.DURING;
+        } else if (fault.contains("after")) {
+            when = AFTER;
+        }
+    }
+}

--- a/rts/lra-examples/pom.xml
+++ b/rts/lra-examples/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.jboss.narayana.quickstart.rts.lra</groupId>
+  <artifactId>lra-examples</artifactId>
+  <version>5.9.1.Final-SNAPSHOT</version>
+  <name>LRA Quickstart Examples</name>
+  <description>Provides examples of how to use transactions with microservices</description>
+  <packaging>pom</packaging>
+  <repositories>
+    <repository>
+      <id>jboss-public-repository-group</id>
+      <name>JBoss Public Maven Repository Group</name>
+      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.6</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <modules>
+    <module>lra-coordinator</module>
+    <module>cdi-participant</module>
+    <module>api-participant</module>
+    <module>cdi-participant-with-coordinator</module>
+    <module>api-participant-with-coordinator</module>
+    <module>mixed-participant-with-coordinator</module>
+  </modules>
+</project>

--- a/rts/lra-examples/run.sh
+++ b/rts/lra-examples/run.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# ALLOW JOBS TO BE BACKGROUNDED
+set -m
+
+swarmjar="lra-participant-example-swarm.jar"
+txlogdir="../txlogs"
+txlogprop="swarm.transactions.object-store-path"
+qsdir="$PWD"
+service_port=8082
+coord_port=8080
+
+usage() { echo -e "$1\nUsage: $0 [-s <service port>] [-c <coordinator port>] [-d <directory>]" 1>&2; exit 1; }
+
+while getopts ":s:c:d:" opt; do
+    case "${opt}" in
+        c) coord_port=${OPTARG};
+           [[ $coord_port =~ ^[0-9]+$ ]] || usage "${OPTARG} is not a valid port" ;;
+        s) service_port=${OPTARG};
+           [[ $service_port =~ ^[0-9]+$ ]] || usage "${OPTARG} is not a valid port" ;;
+        d) qsdir=${OPTARG} ;;
+        *) usage ;;
+    esac
+done
+shift $((OPTIND-1))
+
+[[ -d "$qsdir" ]] || usage "$qsdir is not a valid directory"
+cd $qsdir
+qsname=$(basename "$PWD")
+
+arr=(${qsname//-/ })
+svctype=${arr[0]}
+last=${arr[${#arr[@]} - 1]}
+
+[[ "$svctype" =~ ^(cdi|api|mixed)$ ]] || usage "quickstart directory must start with {cdi|api|mixed}"
+
+[ "$svctype" = "mixed" ] && completions=2 || completions=1
+
+function killpid {
+  kill $2
+  test $? || echo "===== could not kill $1"
+}
+
+function start_coordinator {
+  echo "===== starting external coordinator on port ${coord_port}"
+  java -D${txlogprop}=${txlogdir} -Dswarm.http.port=${coord_port} -jar ../lra-coordinator/target/lra-coordinator-swarm.jar &
+  coord_pid=$!
+  sleep 10
+}
+
+function start_service {
+  echo "===== starting service on port ${service_port}"
+  java -Dswarm.http.port=${service_port} -Dlra.http.port=${coord_port} -D${txlogprop}=${txlogdir} -jar target/${swarmjar} &
+  service_pid=$!
+  sleep 10
+}
+
+function test_service {
+  curl -X PUT -I http://localhost:${service_port}/${svctype} || echo ===== failed
+  sleep 1
+  if [ "$(curl http://localhost:${service_port}/${svctype})" = "$1" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+function start_and_test_service {
+  start_service
+
+  if [ "$1" = "true" ]; then
+    echo " ===== waiting for recovery ......."
+    curl http://localhost:${coord_port}/lra-recovery-coordinator/recovery 
+    # sometimes it can take two scans to complete recovery
+    curl http://localhost:${coord_port}/lra-recovery-coordinator/recovery 
+    echo " ===== recovery should have happened"
+    xcmd="curl http://localhost:${service_port}/${svctype}"
+    svcstatus="$(curl http://localhost:${service_port}/${svctype})"
+    echo "===== after recovery cmd $xcmd returned $svcstatus"
+
+    if [ "$svcstatus" = "${completions} completed and 0 compensated" ]; then
+      echo "===== recovery was successful"
+      res=0
+    else
+      echo "===== recovery failed sleeping for 1 minute to allow debugging"
+      sleep 60
+      res=1
+    fi
+  else
+    echo "===== testing service"
+    test_service "$completions completed and 0 compensated"
+    res=$?
+  fi
+}
+
+function test_recovery {
+  # now test recovery
+  echo "===== injecting a fault which should halt the service on pid $service_pid"
+  curl -X PUT -I "http://localhost:8082/${svctype}?fault=halt${svctype}during"
+  sleep 1
+  # verify that the service is not running
+  kill -0 $service_pid > /dev/null 2>&1
+  if [ "$?" != 1 ]; then
+    echo "${svctype} service on pid $service_pid failed to halt"
+    res=1
+  else
+    start_and_test_service true # restart and test the service
+  fi
+}
+
+echo "===== Running qickstart $qsname in directory $PWD"
+
+if [[ "$last" != "coordinator" ]]; then
+#  start_coordinator
+  echo "===== starting external coordinator on port ${coord_port}"
+  java -D${txlogprop}=${txlogdir} -Dswarm.http.port=${coord_port} -jar ../lra-coordinator/target/lra-coordinator-swarm.jar &
+  coord_pid=$!
+  sleep 10
+else
+  coord_port=${service_port} # the coordinator is running in-VM with the service
+fi
+
+start_and_test_service
+
+test_recovery
+
+# clean up
+
+killpid "service" $service_pid
+[[ -z ${coord_pid+x} ]] || killpid "coordinator" $coord_pid
+
+echo "===== test $qsname completed with status $res"
+
+exit $res

--- a/rts/pom.xml
+++ b/rts/pom.xml
@@ -39,5 +39,6 @@
   <modules>
     <module>at</module>
     <module>lra</module>
+    <module>lra-examples</module>
   </modules>
 </project>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3063

Did rely on jbosstm/narayana#1372 which has now been merged

Notes for the reviewer:

The code could probably do with more comments.

The quickstarts use thorntail uber jars.

1) The quickstart sets out a minimal pom and JAX-RS participant (cdi-participant). 
The pom depends on the lra implementation (lra-filters) and MP LRA api spec jar (microprofile-lra).

The servicve is a JAX-RS resource which counts the number of completion callbacks and it contains
- a method annotated with `@LRA(...)` to control the start and closing of the LRA
- methods annotated with `@Complete` and `@Compensate` to control LRA membership which both count the number of
  completion/compensation callbacks

2) I then attempt to show how to achieve the same behaviour without CDI (ie via the LRAClient plus LRAManagement
interfaces for starting/closing the LRA and to control LRA membership respectively

I think the example is somewhat contrived because, in an attempt to draw out the parallels, I end up relying on CDI to
inject the `StateHolder` application scoped instance and I end up having to work around CDI initialisation issues
during recovery.

3) I then repeat the two approaches (CDI versus programatic) but instead of using a remote LRA coordinator I
embed the coordinator with the servcie by including the pom dependency on the lra-coordinator artefact and
by setting the lra.http.port system property to be the same as the swarm port (swarm.http.port).

4) Finally I combine the two approaches by providing a service which makes JAX-RS calls to the other two services.
I do this by including a dependency on the other two quickstarts.
NB I disabled the automated testing of the `examples-microprofile-lra-mixed-participant-with-coordinator` 
example. It worked when I did the commands manually so I will return to it in another PR.
