### PR TITLE
Reducing size of git clone for foreign repositories

### DIFF
--- a/ArjunaJTS/interop/glassfish/step1.sh
+++ b/ArjunaJTS/interop/glassfish/step1.sh
@@ -9,7 +9,7 @@ function build_wf {
 
   WORKSPACE="$QS_DIR/wildfly/"
 
-  git clone https://github.com/wildfly/wildfly.git
+  git clone --depth=1 https://github.com/wildfly/wildfly.git
   cd $WORKSPACE  
 
   git apply $QS_DIR/interop.wildfly.diff

--- a/XTS/ssl/xts-over-ssh.sh
+++ b/XTS/ssl/xts-over-ssh.sh
@@ -52,7 +52,7 @@ cd "$WORKSPACE"
 
 if [ ! -d "$JBOSS_BIN" ]; then
   echo "Variable \$JBOSS_BIN not defined going to clone 'wildfly' from github"
-  git clone https://github.com/wildfly/wildfly.git
+  git clone --depth=1 https://github.com/wildfly/wildfly.git
   mvn clean install -DskipTests -f wildfly/pom.xml
   JBOSS_BIN=`find wildfly/dist/target -maxdepth 1 -type d -name 'wildfly-*'`
 fi
@@ -64,7 +64,7 @@ cp -r "$JBOSS_BIN" "$JBOSS_SERVER"
 
 if [ ! -d "$QUICKSTART_HOME" ]; then
   echo "Variable \$QUICKSTART_HOME not defined going to clone 'wfly quickstart' from github"
-  git clone https://github.com/wildfly/quickstart.git
+  git clone --depth=1 https://github.com/wildfly/quickstart.git
 fi
 
 if [ ! -d "$WSAT_QUICKSTART_PATH" ]; then

--- a/scripts/hudson/quickstart.sh
+++ b/scripts/hudson/quickstart.sh
@@ -134,7 +134,7 @@ function configure_wildfly {
 
 function build_apache-karaf {
   cd $WORKSPACE
-  git clone https://github.com/apache/karaf.git apache-karaf
+  git clone --depth=1 https://github.com/apache/karaf.git apache-karaf
   if [ $? != 0 ]; then
     comment_on_pull "Karaf clone failed: $BUILD_URL";
     exit -1


### PR DESCRIPTION
Foreign repositories needs to be cloned for showing the integration with other projects. But we normally do not need whole git history and only the top-level layer is fine for us.
