### PR TITLE
[JBTM-3069] Fix for XTS ssl failure

### DIFF
--- a/XTS/ssl/pom.xml
+++ b/XTS/ssl/pom.xml
@@ -37,6 +37,9 @@
         <os>
           <family>unix</family>
         </os>
+        <property>
+          <name>!skipTests</name>
+        </property>
       </activation>
       <build>
         <plugins>

--- a/XTS/wsat-jta-multi_service/pom.xml
+++ b/XTS/wsat-jta-multi_service/pom.xml
@@ -184,6 +184,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>2.3.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>
@@ -195,12 +196,14 @@
         </plugins>
     </build>
 
-
     <profiles>
         <profile>
             <id>arq</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>!no.arq</name>
+                </property>
             </activation>
             <dependencies>
                 <dependency>
@@ -233,9 +236,6 @@
         </profile>
         <profile>
             <id>arqIPv6</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
             <dependencies>
                 <dependency>
                     <groupId>org.wildfly.arquillian</groupId>
@@ -317,6 +317,45 @@
                                             <directory>${env.JBOSS_HOME}</directory>
                                         </resource>
                                     </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>remove.jboss.home.directories</id>
+            <activation>
+                <property>
+                    <name>!no.remove.jboss.home</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-clean-plugin</artifactId>
+                        <version>2.4.1</version>
+                        <executions>
+                            <execution>
+                                <id>remove-jboss-home-directories</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>clean</goal>
+                                </goals>
+                                <configuration>
+                                    <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                                    <filesets>
+                                        <fileset>
+                                            <directory>target/jboss1</directory>
+                                            <followSymlinks>false</followSymlinks>
+                                        </fileset>
+                                        <fileset>
+                                            <directory>target/jboss2</directory>
+                                            <followSymlinks>false</followSymlinks>
+                                        </fileset>
+                                    </filesets>
                                 </configuration>
                             </execution>
                         </executions>

--- a/blacktie/integration1/run.sh
+++ b/blacktie/integration1/run.sh
@@ -45,19 +45,19 @@ fi
 cd ..
 
 #rem "Build Converted XATMI service"
-(cd ejb && mvn install)
+(cd ejb && mvn install -B)
 if [ "$?" != "0" ]; then
 	exit -1
 fi
-(cd ejb/ear/ && mvn install wildfly:deploy)
+(cd ejb/ear/ && mvn install wildfly:deploy -B)
 if [ "$?" != "0" ]; then
 	exit -1
 fi
-(cd xatmi_adapter/ && mvn install)
+(cd xatmi_adapter/ && mvn install -B)
 if [ "$?" != "0" ]; then
 	exit -1
 fi
-(cd xatmi_adapter/ear/ && mvn install wildfly:deploy)
+(cd xatmi_adapter/ear/ && mvn install wildfly:deploy -B)
 if [ "$?" != "0" ]; then
 	exit -1
 fi

--- a/blacktie/jatmibroker-xatmi/mdb-xatmi-service/run.sh
+++ b/blacktie/jatmibroker-xatmi/mdb-xatmi-service/run.sh
@@ -21,11 +21,11 @@ set -m
 echo "Running MDB quickstart"
 
 # RUN THE MDB EXAMPLE
-mvn clean install -DskipTests
+mvn clean install -DskipTests -B
 if [ "$?" != "0" ]; then
 	exit -1
 fi
-(cd ear && mvn clean install wildfly:deploy)
+(cd ear && mvn clean install wildfly:deploy -B)
 if [ "$?" != "0" ]; then
 	exit -1
 fi

--- a/scripts/hudson/quickstart.sh
+++ b/scripts/hudson/quickstart.sh
@@ -130,6 +130,9 @@ function configure_wildfly {
   export JBOSS_HOME=`pwd`/${WILDFLY_DIST_ZIP%.zip}
   cp $JBOSS_HOME/docs/examples/configs/standalone-xts.xml $JBOSS_HOME/standalone/configuration/
   cp $JBOSS_HOME/docs/examples/configs/standalone-rts.xml $JBOSS_HOME/standalone/configuration/
+  # cleaning
+  rm -f artifacts.zip
+  rm -rf "${WILDFLY_DIST_ZIP}"
 }
 
 function build_apache-karaf {


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3069

Fix for the XTS quickstarts over ssl. The quickstart itself is taken from WFLY quickstart repo and then adjusted to run with SSL. There was change on using bom in snapshot version in the WFLY repo and it was needed to accomodate with that fact.

On top of the fix there are serveral more changes which should ensure less space is used during running the quickstarts. There are added cleaning mechanism in the scripts and maven. And for the XTS/ssl the WildFly is not copied to two instances at all and both servers are run from the same location only data dirs are specific for each instance. This should hopefully help for https://github.com/jbosstm/quickstart/pull/235 to be successfully run. 