### PR TITLE
JBTM-3103 Disable LRA api quickstarts

### DIFF
--- a/rts/lra-examples/api-participant-with-coordinator/pom.xml
+++ b/rts/lra-examples/api-participant-with-coordinator/pom.xml
@@ -107,6 +107,7 @@
                                     <goal>exec</goal>
                                 </goals>
                                 <configuration>
+                                    <skip>true</skip>
                                     <executable>bash</executable>
                                     <commandlineArgs>${basedir}/../run.sh</commandlineArgs>
                                 </configuration>

--- a/rts/lra-examples/api-participant-with-coordinator/pom.xml
+++ b/rts/lra-examples/api-participant-with-coordinator/pom.xml
@@ -18,7 +18,7 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.wildfly-swarm>2017.8.1</version.wildfly-swarm>
-        <version.microprofile.lra>1.0-20181217.132756-202</version.microprofile.lra>
+        <version.microprofile.lra>1.0-20190122.071206-242</version.microprofile.lra>
     </properties>
 
     <repositories>

--- a/rts/lra-examples/api-participant/pom.xml
+++ b/rts/lra-examples/api-participant/pom.xml
@@ -18,7 +18,7 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.wildfly-swarm>2017.8.1</version.wildfly-swarm>
-        <version.microprofile.lra>1.0-20181217.132756-202</version.microprofile.lra>
+        <version.microprofile.lra>1.0-20190122.071206-242</version.microprofile.lra>
     </properties>
 
     <repositories>

--- a/rts/lra-examples/api-participant/pom.xml
+++ b/rts/lra-examples/api-participant/pom.xml
@@ -143,6 +143,7 @@
                                     <goal>exec</goal>
                                 </goals>
                                 <configuration>
+                                    <skip>true</skip>
                                     <executable>bash</executable>
                                     <commandlineArgs>${basedir}/../run.sh</commandlineArgs>
                                 </configuration>

--- a/rts/lra-examples/api-participant/src/main/java/io/narayana/rts/lra/ParticipantDeserializer.java
+++ b/rts/lra-examples/api-participant/src/main/java/io/narayana/rts/lra/ParticipantDeserializer.java
@@ -1,15 +1,15 @@
 package io.narayana.rts.lra;
 
 import org.eclipse.microprofile.lra.participant.LRAParticipant;
-import org.eclipse.microprofile.lra.participant.LRAParticipantDeserializer;
+//import org.eclipse.microprofile.lra.participant.LRAParticipantDeserializer;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.net.URL;
 
-public class ParticipantDeserializer implements LRAParticipantDeserializer {
-    @Override
+public class ParticipantDeserializer {//implements LRAParticipantDeserializer {
+//    @Override
     public LRAParticipant deserialize(URL lraId, byte[] data) {
         try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(data))) {
             return (LRAParticipant) ois.readObject();

--- a/rts/lra-examples/api-participant/src/main/java/io/narayana/rts/lra/ProxyBasedResource.java
+++ b/rts/lra-examples/api-participant/src/main/java/io/narayana/rts/lra/ProxyBasedResource.java
@@ -39,18 +39,18 @@ public class ProxyBasedResource implements LRAParticipant, Serializable {
     @Inject
     private LRAManagement lraManagement;
 
-    @Inject
-    private ParticipantDeserializer participantDeserializer;
+//    @Inject
+//    private ParticipantDeserializer participantDeserializer;
 
-    @PostConstruct
-    private void postConstruct() {
-        lraManagement.registerDeserializer(participantDeserializer);
-    }
-
-    @PreDestroy
-    private void preDestroy() {
-        lraManagement.unregisterDeserializer(participantDeserializer);
-    }
+//    @PostConstruct
+//    private void postConstruct() {
+//        lraManagement.registerDeserializer(participantDeserializer);
+//    }
+//
+//    @PreDestroy
+//    private void preDestroy() {
+//        lraManagement.unregisterDeserializer(participantDeserializer);
+//    }
 
     private void writeObject(ObjectOutputStream out) throws IOException {
     }

--- a/rts/lra-examples/cdi-participant-with-coordinator/pom.xml
+++ b/rts/lra-examples/cdi-participant-with-coordinator/pom.xml
@@ -18,7 +18,7 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.wildfly-swarm>2017.8.1</version.wildfly-swarm>
-        <version.microprofile.lra>1.0-20181217.132756-202</version.microprofile.lra>
+        <version.microprofile.lra>1.0-20190122.071206-242</version.microprofile.lra>
     </properties>
 
     <repositories>

--- a/rts/lra-examples/cdi-participant/pom.xml
+++ b/rts/lra-examples/cdi-participant/pom.xml
@@ -18,7 +18,7 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.wildfly-swarm>2017.8.1</version.wildfly-swarm>
-        <version.microprofile.lra>1.0-20181217.132756-202</version.microprofile.lra>
+        <version.microprofile.lra>1.0-20190122.071206-242</version.microprofile.lra>
     </properties>
 
     <repositories>

--- a/rts/lra-examples/lra-coordinator/pom.xml
+++ b/rts/lra-examples/lra-coordinator/pom.xml
@@ -19,7 +19,7 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.wildfly-swarm>2018.5.0</version.wildfly-swarm>
-        <version.microprofile.lra>1.0-20181217.132756-202</version.microprofile.lra>
+        <version.microprofile.lra>1.0-20190122.071206-242</version.microprofile.lra>
     </properties>
 
     <repositories>

--- a/rts/lra-examples/mixed-participant-with-coordinator/pom.xml
+++ b/rts/lra-examples/mixed-participant-with-coordinator/pom.xml
@@ -18,7 +18,7 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.wildfly-swarm>2017.8.1</version.wildfly-swarm>
-        <version.microprofile.lra>1.0-20181217.132756-202</version.microprofile.lra>
+        <version.microprofile.lra>1.0-20190122.071206-242</version.microprofile.lra>
     </properties>
 
     <repositories>

--- a/rts/lra/flight-service/src/main/java/io/narayana/rts/lra/demo/flight/FlightParticipant.java
+++ b/rts/lra/flight-service/src/main/java/io/narayana/rts/lra/demo/flight/FlightParticipant.java
@@ -58,7 +58,7 @@ public class FlightParticipant {
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
-    @LRA(value = LRA.Type.MANDATORY, terminal = false)
+    @LRA(value = LRA.Type.MANDATORY, end = false)
     @NestedLRA
     public Booking bookFlight(@HeaderParam(LRA_HTTP_HEADER) String lraId,
                               @QueryParam("flightNumber") @DefaultValue("") String flightNumber) {

--- a/rts/lra/hotel-service/src/main/java/io/narayana/rts/lra/demo/hotel/HotelParticipant.java
+++ b/rts/lra/hotel-service/src/main/java/io/narayana/rts/lra/demo/hotel/HotelParticipant.java
@@ -56,7 +56,7 @@ public class HotelParticipant {
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
-    @LRA(value = LRA.Type.REQUIRED, terminal = false)
+    @LRA(value = LRA.Type.REQUIRED, end = false)
     public Booking bookRoom(@HeaderParam(LRA_HTTP_HEADER) String lraId,
                             @QueryParam("hotelName") @DefaultValue("Default") String hotelName) {
         return service.book(lraId, hotelName);

--- a/rts/lra/trip-controller/src/main/java/io/narayana/rts/lra/demo/tripcontroller/TripController.java
+++ b/rts/lra/trip-controller/src/main/java/io/narayana/rts/lra/demo/tripcontroller/TripController.java
@@ -112,7 +112,7 @@ public class TripController {
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     // terminal is false because we want the LRA to be associated with a booking until the user confirms the booking
-    @LRA(terminal = false)
+    @LRA(end = false)
     public Response bookTrip(@QueryParam("hotelName") @DefaultValue("TheGrand") String hotelName,
                              @QueryParam("flightNumber1") @DefaultValue("firstClass") String flightNumber,
                              @QueryParam("flightNumber2") @DefaultValue("secondClass") String altFlightNumber,


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3103

The issue disables the api participant quckstarts (see issue for the reason).
 
This fix also partially address issue https://issues.jboss.org/browse/JBTM-3087 (and is needed to avoid compilation errors) 
