### PR TITLE
JBTM-3116 Temporarily disable LRA quickstarts

### DIFF
--- a/rts/pom.xml
+++ b/rts/pom.xml
@@ -38,7 +38,10 @@
   </repositories>
   <modules>
     <module>at</module>
+<!-- these modules have been temporarily disabled
+     and will be re-enabled when the MP LRA spec is more stable
     <module>lra</module>
     <module>lra-examples</module>
+-->
   </modules>
 </project>


### PR DESCRIPTION
Signed-off-by: Michael Musgrove <mmusgrov@redhat.com>

https://issues.jboss.org/browse/JBTM-3116

This PR disables the LRA quickstarts until the narayana LRA spec implementation catches up with the latest round of spec API changes.
