### PR TITLE
[JBTM-3203] workaround: disabling XTS over SSL until WFLY bom with jakarta dependency is released

### DIFF
--- a/XTS/pom.xml
+++ b/XTS/pom.xml
@@ -44,6 +44,6 @@
     <module>raw-xts-api-demo</module>
     <module>wsat-jta-multi_service</module>
     <module>wsat-jta-multi_hop</module>
-    <module>ssl</module>
+    <!--<module>ssl</module> temporarily disabled, see JBTM-3203 -->
   </modules>
 </project>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3203

temporary workaround until wfly bom with jakarta dependency is released
https://github.com/wildfly/boms/blob/849ebf584bbf15c65d0bc42da239a290475f9228/jakartaee8/pom.xml#L120