### PR TITLE
[JBTM-3203] enabling XTS over SSL with correct bom with jakarta depen…

### DIFF
--- a/XTS/pom.xml
+++ b/XTS/pom.xml
@@ -44,6 +44,6 @@
     <module>raw-xts-api-demo</module>
     <module>wsat-jta-multi_service</module>
     <module>wsat-jta-multi_hop</module>
-    <!--<module>ssl</module> temporarily disabled, see JBTM-3203 -->
+    <module>ssl</module>
   </modules>
 </project>

--- a/XTS/ssl/xts-over-ssh.sh
+++ b/XTS/ssl/xts-over-ssh.sh
@@ -132,7 +132,7 @@ sed "s#http://localhost:8080/wsat-simple/RestaurantServiceAT?wsdl#https://localh
 
 # -s ../settings.xml
 DEPLOYMENT_NAME=wsat-simple.war
-mvn clean install -B -e -Dversion.server.bom=17.0.0.Beta1 -DskipTests -Dinsecure.repositories=WARN
+mvn clean install -B -e -Dversion.server.bom=18.0.0.Final -DskipTests -Dinsecure.repositories=WARN
 [ $? -ne 0 ] && echo "Failure to build deployment '$DEPLOYMENT_NAME' from quickstart '$WSAT_QUICKSTART_PATH'"
 
 # Settings for client


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3203

WFLY18 is released, no need of temporary fix https://github.com/jbosstm/quickstart/pull/259 anymore
Now the quickstart can be enabled with the fix.