### PR TITLE
TEST ONLY: If the test is faster than millis can be retrieved then wait for a second for the new name of the the customer to use

### DIFF
--- a/ArjunaJTA/jee_transactional_app/src/test/java/org/jboss/narayana/quickstarts/TestManagedBeanCustomerManager.java
+++ b/ArjunaJTA/jee_transactional_app/src/test/java/org/jboss/narayana/quickstarts/TestManagedBeanCustomerManager.java
@@ -42,6 +42,8 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.junit.Assert.fail;
+
 @RunWith(Arquillian.class)
 public class TestManagedBeanCustomerManager {
 	@Inject
@@ -90,8 +92,9 @@ public class TestManagedBeanCustomerManager {
 		int size = managedBeanCustomerManager.getCustomerCount();
 
 		// Create a new customer
+		long time = System.currentTimeMillis();
 		managedBeanCustomerManager.addCustomer("Test"
-				+ System.currentTimeMillis());
+				+ time);
 
 		// Get the initial number of customers
 		response = managedBeanCustomerManager.getCustomerCount();
@@ -99,8 +102,17 @@ public class TestManagedBeanCustomerManager {
 		size = response;
 
 		// Create a new customer
+		long time2 = System.currentTimeMillis();
+		if (time2 == time) {
+			Thread.currentThread().sleep(1000);
+			time2 = System.currentTimeMillis();
+			if (time2 == time) {
+				fail("time was the same");
+			}
+		}
+		
 		managedBeanCustomerManager.addCustomer("Test"
-				+ System.currentTimeMillis());
+				+ time2);
 
 		// Check that one extra customer was created
 		response = managedBeanCustomerManager.getCustomerCount();


### PR DESCRIPTION
I saw a CI failure where it seems that the number of customers was not as expected and it looked like a constraint violation on the PK. This PR should ensure if System.currentTimeMillis was the same at the two points then we would delay the run briefly to make sure the name would be different