### PR TITLE
[JBTM-3263] glassfish for interop quickstart is available on github

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ target/
 ObjectStore/
 PutObjectStoreDirHere/
 
+ArjunaJTS/interop/glassfish/tmp/
+
 instantclient_11_2/
 jboss-as
 jbossesb-4.9.zip

--- a/ArjunaJTS/interop/glassfish/init.sh
+++ b/ArjunaJTS/interop/glassfish/init.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -x
 
 function fatal {
   echo "$1"; exit 1
@@ -10,10 +10,10 @@ function fatal {
 
 QS_DIR=${WORKSPACE}/ArjunaJTS/interop/glassfish
 
-if ls ${QS_DIR}/wildfly-*/ 1> /dev/null 2>&1; then
-  cd ${QS_DIR}/wildfly-*/
+if ls ${QS_DIR}/tmp/wildfly-*/ 1> /dev/null 2>&1; then
+  cd ${QS_DIR}/tmp/wildfly-*/
   export JBOSS_HOME=$(pwd)
-  cd ..
+  cd -
 fi
 
 if [ -d "/home/jenkins/glassfish4" ]; then

--- a/ArjunaJTS/interop/glassfish/run.sh
+++ b/ArjunaJTS/interop/glassfish/run.sh
@@ -2,8 +2,8 @@
 set -ex
 
 echo "===== JTS interop quickstart: step 1 (compile gf and wf):"; ./step1.sh; sleep 3
-echo "===== JTS interop quickstart: step 2 (start WildFly):"; ./step2.sh; sleep 10
-echo "===== JTS interop quickstart: step 3 (start GlassFish):"; ./step3.sh; sleep 10
+echo "===== JTS interop quickstart: step 2 (start GlassFish):"; ./step2.sh; sleep 10
+echo "===== JTS interop quickstart: step 3 (start WildFly):"; ./step3.sh; sleep 10
 trap ./step7.sh EXIT
 echo "===== JTS interop quickstart: step 4 (deploy EJBs):"; ./step4.sh; sleep 10
 echo "===== JTS interop quickstart: step 5 (EJB call gf -> wf):"; ./step5.sh; sleep 4

--- a/ArjunaJTS/interop/glassfish/step1.sh
+++ b/ArjunaJTS/interop/glassfish/step1.sh
@@ -7,10 +7,12 @@ set -e
 function build_wf {
   WS=$WORKSPACE
 
-  WORKSPACE="$QS_DIR/wildfly/"
+  cd "$QS_DIR/tmp/"
+  WORKSPACE="$QS_DIR/tmp/wildfly/"
 
+  rm -rf "$WORKSPACE"
   git clone --depth=1 https://github.com/wildfly/wildfly.git
-  cd $WORKSPACE  
+  cd $WORKSPACE
 
   git apply $QS_DIR/interop.wildfly.diff
 
@@ -18,7 +20,7 @@ function build_wf {
   
 
   WILDFLY_MASTER_VERSION=`awk '/wildfly-parent/ { while(!/<version>/) {getline;} print; }' pom.xml | cut -d \< -f 2|cut -d \> -f 2`
-  cp -rp build/target/wildfly-$WILDFLY_MASTER_VERSION/ ${QS_DIR}/
+  cp -rp build/target/wildfly-$WILDFLY_MASTER_VERSION/ ${QS_DIR}/tmp/
   
   cd ${QS_DIR}
   rm -rf $WORKSPACE
@@ -30,14 +32,15 @@ function build_gf {
   GLASSFISH=${GLASSFISH:=xyz}
   if [ ! -d $GLASSFISH ]; then
     echo looking for glassfish
-    # if we are not running using jenkins CI then get the GlassFish sources via svn
+    # if we are not running using jenkins CI then get the GlassFish sources via git clone
     if [ -z ${JENKINS_HOST+x} ]; then
-      echo getting glassfish via svn
-      svn checkout https://svn.java.net/svn/glassfish~svn/trunk/main $QS_DIR/tmp/glassfish4
+      echo "getting glassfish via git clone; QS_DIR is at $QS_DIR"
+      git clone --depth=1 https://github.com/javaee/glassfish -b 4.1.2 $QS_DIR/tmp/glassfish4
       cd $QS_DIR/tmp/glassfish4
       patch -p0 -i $QS_DIR/GLASSFISH-21532.diff  
       mvn install -B -Dmaven.wagon.http.ssl.insecure=true -Dmaven.wagon.http.ssl.allowall=true -DskipTests  
       export GLASSFISH=$QS_DIR/tmp/glassfish4/appserver/distributions/glassfish/target/stage/glassfish4
+      cd -
     fi
   fi
 

--- a/ArjunaJTS/interop/glassfish/step2.sh
+++ b/ArjunaJTS/interop/glassfish/step2.sh
@@ -2,11 +2,12 @@
 source init.sh
 set -ex
 
-# start jboss and put it into JTS mode
-[ -d "$JBOSS_HOME"  ] || fatal "file not found: $JBOSS_HOME"
-cd $JBOSS_HOME
-./bin/standalone.sh -c standalone-full.xml -Djboss.tx.node.id=1 -Dcom.arjuna.ats.jts.transactionServiceId=0 &
-sleep 10
-./bin/jboss-cli.sh --connect --file=$QS_DIR/configure-jts-transactions.cli
+# Start a glassfish server
+cd $QS_DIR
 
-# shut it down using the script step7.sh
+export PATH=$GLASSFISH/bin:$PATH
+
+#asadmin start-domain --debug --verbose domain1 
+asadmin start-domain domain1
+asadmin set configs.config.server-config.network-config.network-listeners.network-listener.http-listener-1.port=7080
+

--- a/ArjunaJTS/interop/glassfish/step3.sh
+++ b/ArjunaJTS/interop/glassfish/step3.sh
@@ -2,12 +2,11 @@
 source init.sh
 set -ex
 
-# Start a glassfish server
-cd $QS_DIR
+# start jboss and put it into JTS mode
+[ -d "$JBOSS_HOME"  ] || fatal "file not found: $JBOSS_HOME"
+cd $JBOSS_HOME
+./bin/standalone.sh -c standalone-full.xml -Djboss.tx.node.id=1 -Dcom.arjuna.ats.jts.transactionServiceId=0 &
+sleep 10
+./bin/jboss-cli.sh --connect --file=$QS_DIR/configure-jts-transactions.cli
 
-export PATH=$GLASSFISH/bin:$PATH
-
-#asadmin start-domain --debug domain1 
-asadmin start-domain domain1
-asadmin set configs.config.server-config.network-config.network-listeners.network-listener.http-listener-1.port=7080
-
+# shut it down using the script step7.sh

--- a/ArjunaJTS/interop/glassfish/step4.sh
+++ b/ArjunaJTS/interop/glassfish/step4.sh
@@ -4,7 +4,7 @@ set -ex
 
 cd $QS_DIR
 # deploy ejbs to glassfish
-./ejb_operations.sh -a gf1 -f ../test-ejbs/target/ejbtest.war
+./ejb_operations.sh -a gf1 -f "${QS_DIR}/../test-ejbs/target/ejbtest.war"
 
 # deploy ejbs to WildFly
-./ejb_operations.sh -a wf1 -f ../test-ejbs/target/ejbtest.war
+./ejb_operations.sh -a wf1 -f "${QS_DIR}/../test-ejbs/target/ejbtest.war"

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Change directory into the required quickstart and follow the instructions in the
 
 To run the quickstarts:
 
-1. set `WORKSPACE` (to the root of the quickstart checkout)
+1. set `WORKSPACE` (to the root directory where the quickstart repository was cloned)
 2. set `JBOSSAS_IP_ADDR` (default is `localhost`)
 3. set `JBOSS_HOME` (to the path of WildFly server, you can download the server at http://wildfly.org/downloads)
 4. `mvn clean install`


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3263

When verifying JBTM-3132 we found the glassfish interop does not work on local machine. There is an `if` which makes this working on Narayana CI where glassfish sources are directly available. 

This PR changes the quickstart to work with glassfish 4.2.1 from github on local machine.
This needed few more changes as e.g. this version of glassfish was not starting when port `8080` was occupied by WFLY. Thus I changed order of the launching of the servers - glassfish is started first, changes the port to stop occupying the `8080` and then wildfly may be started.