### PR TITLE
[JBTM-3269] commit markable quickstart to work on JKD9+ on Windows as well

### DIFF
--- a/wildfly/commit-markable-resource/pom.xml
+++ b/wildfly/commit-markable-resource/pom.xml
@@ -251,6 +251,9 @@
               <os>
                   <family>windows</family>
               </os>
+              <file>
+                  <exists>${java.home}/../lib/tools.jar</exists>
+              </file>
           </activation>
           <properties>
               <xboot.classpath>"-Xbootclasspath/a:${java.home}\..\lib\tools.jar"</xboot.classpath>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3269

fix JDK9+ execution for CMR quickstart on Windows