### PR TITLE
JBTM-3306: Quickstart jca-and-tomcat doesn't work on JDK11

### DIFF
--- a/jca-and-tomcat/pom.xml
+++ b/jca-and-tomcat/pom.xml
@@ -77,6 +77,7 @@
         <version.h2>1.4.195</version.h2>
         <version.junit>4.12</version.junit>
         <version.org.jboss.spec.javax.transaction>1.0.0.Final</version.org.jboss.spec.javax.transaction>
+        <version.jakarta.xml.bind>2.3.2</version.jakarta.xml.bind>
     </properties>
 
     <repositories>
@@ -467,6 +468,11 @@
             <artifactId>junit</artifactId>
             <version>${version.junit}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>${version.jakarta.xml.bind}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3306