### PR TITLE
JBTM-3375 JTS recovery failures if the orphanSafetyInterval is miscon…

### DIFF
--- a/ArjunaJTS/recovery/src/main/java/AbstractExampleXAResource.java
+++ b/ArjunaJTS/recovery/src/main/java/AbstractExampleXAResource.java
@@ -105,7 +105,9 @@ public abstract class AbstractExampleXAResource implements XAResource {
      * @exception javax.transaction.xa.XAException <description>
      */
     public synchronized void commit(Xid xid, boolean onePhase) throws XAException {
-        System.out.println("******\n" + this.getClass().getName() + ": " + "commit,xid=" + xid + ",onePhase=" + onePhase);
+//        System.out.println("******\n******\n" + this.getClass().getName() + ": " + "commit,xid=" + xid + ",onePhase=" + onePhase);
+        System.out.printf("******\n******\n%s: commit,xid=%s,onePhase=%b%n******\n******\n",
+                this.getClass().getName(), xid, onePhase);
 
         if (!recovered) {
             Runtime.getRuntime().halt(0);


### PR DESCRIPTION
https://github.com/mmusgrov/quickstart-1/pull/new/JBTM-3375

This problem with the JTS recovery quickstart is caused by an invalid value of the orphanSafetyInterval configuration property.
In more detail:

     * During a recovery pass we perform bottom up recovery where we ask the resources
     * for the Xids (transaction branches) that they know about. To avoid attempting recovery
     * on resources that are about to be committed by an active (ie in flight) transaction
     * we back off for a certain period (controlled via a property called orphanSafetyInterval
     * ie it controls the amount of time to wait before deciding whether the Xid is orphaned
     * and needs to be committed). When bottom up recovery has finished we garbage collect
     * the Xids. Then, after waiting for a certain period (controlled via a property called
     * periodicRecoveryPeriod), we repeat the whole procedure. Therefore, if the
     * orphanSafetyInterval is longer than the periodicRecoveryPeriod then the Xid will never
     * be chosen as a candidate for recovery. In other words ensure that the
     * orphanSafetyInterval is shorter than the periodicRecoveryPeriod.