### PR TITLE
[JBTM-3497] Upgrade resteasy-client to 4.5.7.Final

### DIFF
--- a/rts/lra/flight-service/pom.xml
+++ b/rts/lra/flight-service/pom.xml
@@ -22,8 +22,8 @@
         <lra.coordinator.url>http://localhost:8080/lra-coordinator</lra.coordinator.url>
         <service.http.port>${thorntail.http.port}</service.http.port>
 
-        <version.resteasy-client>3.1.3.Final</version.resteasy-client>
         <version.narayana>${project.version}</version.narayana>
+        <version.resteasy-client>4.5.7.Final</version.resteasy-client>
         <version.json>1.0</version.json>
 
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/rts/lra/hotel-service/pom.xml
+++ b/rts/lra/hotel-service/pom.xml
@@ -23,7 +23,7 @@
         <service.http.port>${thorntail.http.port}</service.http.port>
 
         <version.wildfly-swarm>2017.8.1</version.wildfly-swarm>
-        <version.resteasy-client>3.1.3.Final</version.resteasy-client>
+        <version.resteasy-client>3.9.1.Final</version.resteasy-client>
         <version.narayana>5.12.1.Final-SNAPSHOT</version.narayana>
 
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/rts/lra/trip-client/pom.xml
+++ b/rts/lra/trip-client/pom.xml
@@ -22,7 +22,7 @@
         <lra.coordinator.url>http://localhost:8080/lra-coordinator</lra.coordinator.url>
         <service.http.port>${swarm.http.port}</service.http.port>
 
-        <version.resteasy-client>3.1.3.Final</version.resteasy-client>
+        <version.resteasy-client>3.9.1.Final</version.resteasy-client>
         <version.narayana>5.12.1.Final-SNAPSHOT</version.narayana>
 
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/rts/lra/trip-controller/pom.xml
+++ b/rts/lra/trip-controller/pom.xml
@@ -22,7 +22,7 @@
         <lra.coordinator.url>http://localhost:8080/lra-coordinator</lra.coordinator.url>
         <service.http.port>${thorntail.http.port}</service.http.port>
 
-        <version.resteasy-client>3.1.3.Final</version.resteasy-client>
+        <version.resteasy-client>3.9.1.Final</version.resteasy-client>
         <version.narayana>5.12.1.Final-SNAPSHOT</version.narayana>
 
         <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3497