### PR TITLE
JBTM-3558 temporarily disable jta-service quickstart

### DIFF
--- a/rts/at/jta-service/README.md
+++ b/rts/at/jta-service/README.md
@@ -1,3 +1,6 @@
+Remark: This quickstart requires WildFly 24 and earlier.
+To run with a later version, issue JBTM-3558 needs to be resolved.
+
 REST-AT with JTA: Example of Using REST-AT with JPA and JMS
 ======================================================
 Author: Gytis Trikleris (gytis@redhat.com)

--- a/rts/at/pom.xml
+++ b/rts/at/pom.xml
@@ -72,7 +72,9 @@
     <module>simple</module>
     <module>service</module>
     <module>recovery</module>
+    <!-- see issue JBTM-3558
     <module>jta-service</module>
+    -->
     <module>undertow</module>
   </modules>
 </project>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3558

This PR temporarily disables the jta-service quickstart with a note that it should be tested against pre WildFly 25 releases (and to run on later WildFly versions JBTM-3558 needs fixing). I have done this because it blocks releasing narayana master and the defect is a test only issue with a workaround.