### PR TITLE
Upgrading to H2 seems to have stopped allowing value as a column name

### DIFF
--- a/jta-and-hibernate-standalone/src/main/java/org/jboss/narayana/quickstart/jta/QuickstartEntity.java
+++ b/jta-and-hibernate-standalone/src/main/java/org/jboss/narayana/quickstart/jta/QuickstartEntity.java
@@ -16,10 +16,12 @@
  */
 package org.jboss.narayana.quickstart.jta;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+
 
 /**
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
@@ -28,9 +30,10 @@ import javax.persistence.Id;
 public class QuickstartEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
     private Long id;
 
+    @Column(name="value2")
     private String value;
 
     public QuickstartEntity() {

--- a/jta-and-hibernate-standalone/src/test/java/org/jboss/narayana/quickstart/jta/TestCase.java
+++ b/jta-and-hibernate-standalone/src/test/java/org/jboss/narayana/quickstart/jta/TestCase.java
@@ -183,10 +183,10 @@ public class TestCase {
         Connection connection = dataSource.getConnection(TransactionalConnectionProvider.USERNAME,
                 TransactionalConnectionProvider.PASSWORD);
         Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery("SELECT `value` FROM `QuickstartEntity`");
+        ResultSet resultSet = statement.executeQuery("SELECT `value2` FROM `QuickstartEntity`");
         List<QuickstartEntity> entities = new LinkedList<>();
         while (resultSet.next()) {
-            entities.add(new QuickstartEntity(resultSet.getString("value")));
+            entities.add(new QuickstartEntity(resultSet.getString("value2")));
         }
         resultSet.close();
         statement.close();

--- a/transactionaldriver/transactionaldriver-standalone/src/main/java/io/narayana/util/DBUtils.java
+++ b/transactionaldriver/transactionaldriver-standalone/src/main/java/io/narayana/util/DBUtils.java
@@ -61,7 +61,7 @@ public class DBUtils {
     private static final String DB_PG_PASSWORD = "test";
 
     private static String TEST_TABLE_NAME = "TXN_DRIVER_TEST";
-    private static String CREATE_TABLE = String.format("CREATE TABLE %s(id int primary key, value varchar(42))", TEST_TABLE_NAME);
+    private static String CREATE_TABLE = String.format("CREATE TABLE %s(id int primary key, value2 varchar(42))", TEST_TABLE_NAME);
     private static String DROP_TABLE = String.format("DROP TABLE %s", TEST_TABLE_NAME);
     private static String SELECT_QUERY = String.format("SELECT * FROM %s", TEST_TABLE_NAME);
 
@@ -72,7 +72,7 @@ public class DBUtils {
     public static final String DB_USER = isH2 ? DB_H2_USER : DB_PG_USER;
     public static final String DB_PASSWORD = isH2 ? DB_H2_PASSWORD : DB_PG_PASSWORD;
 
-    public static String INSERT_STATEMENT = String.format("INSERT INTO %s (id, value) values (?,?)", TEST_TABLE_NAME);
+    public static String INSERT_STATEMENT = String.format("INSERT INTO %s (id, value2) values (?,?)", TEST_TABLE_NAME);
 
     public static Connection getConnection(String dbname) {
         if(isH2) return getH2Connection(dbname);


### PR DESCRIPTION
This seemed to help but still some of the quickstarts failed. It seems value was not allowed as a column name. Having a look after it seems to be in this list: http://h2database.com/html/advanced.html#keywords