### PR TITLE
JBTM-3584: Prevent quickstarts that require JDK11 from running on JDK8

### DIFF
--- a/ArjunaJTA/pom.xml
+++ b/ArjunaJTA/pom.xml
@@ -141,11 +141,22 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <profiles>
+    <profile>
+      <id>include-for-JDK11-above-versions</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <modules>
+        <module>jee_transactional_app</module>
+      </modules>
+    </profile>
+  </profiles>
+
   <modules>
     <module>javax_transaction</module>
     <module>object_store/</module>
     <module>recovery</module>
     <module>maven</module>
-    <module>jee_transactional_app</module>
   </modules>
 </project>

--- a/ArjunaJTS/interop/pom.xml
+++ b/ArjunaJTS/interop/pom.xml
@@ -68,7 +68,6 @@
         <jdk>(,9)</jdk>
       </activation>
       <modules>
-        <module>glassfish</module>
       </modules>
     </profile>
   </profiles>
@@ -77,6 +76,5 @@
   <modules>
     <module>resource</module>
     <module>test-ejbs</module>
-    <module>glassfish</module>
   </modules>
 </project>

--- a/XTS/pom.xml
+++ b/XTS/pom.xml
@@ -44,10 +44,20 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>include-for-JDK11-above-versions</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <modules>
+        <module>wsat-jta-multi_service</module>
+        <module>wsat-jta-multi_hop</module>
+        <module>ssl</module>
+      </modules>
+    </profile>
+  </profiles>
   <modules>
     <module>raw-xts-api-demo</module>
-    <module>wsat-jta-multi_service</module>
-    <module>wsat-jta-multi_hop</module>
-    <module>ssl</module>
   </modules>
 </project>

--- a/compensating-transactions/pom.xml
+++ b/compensating-transactions/pom.xml
@@ -44,9 +44,20 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>include-for-JDK11-above-versions</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <modules>
+        <module>non-transactional_resource</module>
+        <module>travel-agent</module>
+      </modules>
+    </profile>
+  </profiles>
   <modules>
-    <module>non-transactional_resource</module>
-    <module>travel-agent</module>
     <module>mongodb-simple</module>
   </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,6 @@
     <module>dbcp2-and-tomcat</module>
     <module>jca-and-hibernate</module>
     <module>jta-1_2-standalone</module>
-    <module>jta-1_2-in-wildfly</module>
     <module>spring</module>
     <module>ArjunaCore</module>
     <module>ArjunaJTA</module>
@@ -139,7 +138,6 @@
     <module>rts</module>
     <module>XTS</module>
     <module>wildfly/setCheckedActionFactoryExample</module>
-    <module>wildfly/commit-markable-resource</module>
     <module>STM</module>
     <module>jts-docker</module>
     <!-- JBTM-3565 disable the osgi quickstart until it is fixed -->
@@ -163,6 +161,16 @@
           --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED
           --add-modules=java.se</modular.jdk.args>
       </properties>
+    </profile>
+    <profile>
+      <id>include-for-JDK11-above-versions</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <modules>
+        <module>jta-1_2-in-wildfly</module>
+        <module>wildfly/commit-markable-resource</module>
+      </modules>
     </profile>
   </profiles>
 </project>

--- a/rts/at/jta-service/pom.xml
+++ b/rts/at/jta-service/pom.xml
@@ -146,11 +146,16 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>include-for-JDK11-above-versions</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <modules>
+                <module>jpa</module>
+                <module>jms</module>
+            </modules>
+        </profile>
     </profiles>
-
-    <modules>
-        <module>jpa</module>
-        <module>jms</module>
-    </modules>
 
 </project>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3584