### PR TITLE
[JBTM-3668] Update resteasy dependencies in quickstarts

### DIFF
--- a/dbcp2-and-tomcat/pom.xml
+++ b/dbcp2-and-tomcat/pom.xml
@@ -30,7 +30,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jackson-provider</artifactId>
+            <artifactId>resteasy-jackson2-provider</artifactId>
             <version>${version.resteasy}</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,6 @@
         <server.jvm.args>${jvm.args.other} ${jvm.args.memory} ${jvm.args.debug} ${jvm.args.modular}</server.jvm.args>
         <spring.version>2.0.9.RELEASE</spring.version>
         <test.logs.to.file>false</test.logs.to.file>
-        <undertow.io.version>2.2.19.Final</undertow.io.version>
         <version.agroal>1.3</version.agroal>
 <!--         arquillian -->
         <version.arquillian.byteman>1.1.0</version.arquillian.byteman>
@@ -217,7 +216,7 @@
         <version.jboss-transaction-api>1.1.1.Final</version.jboss-transaction-api>
         <version.jboss.bom>1.0.7.Final</version.jboss.bom>
         <version.jboss.logging.spi>2.2.0.CR1</version.jboss.logging.spi>
-        <version.jboss.logging>3.1.4.GA</version.jboss.logging>
+        <version.jboss.logging>3.5.0.Final</version.jboss.logging>
         <version.jboss.maven.plugin>7.3.Final</version.jboss.maven.plugin>
         <version.jboss.spec.javaee.6.0>3.0.2.Final</version.jboss.spec.javaee.6.0>
         
@@ -255,10 +254,8 @@
         <version.org.wildfly.arquillian>4.0.0.Alpha5</version.org.wildfly.arquillian>
         <version.plugin.maven.dependency>2.3</version.plugin.maven.dependency>
         <version.postgresql>9.1-901.jdbc4</version.postgresql>
-        <version.resteasy.api>3.0.5.Final</version.resteasy.api>
-        <version.resteasy.client>4.6.0.Final</version.resteasy.client>
-        <version.resteasy.jaxrs>4.0.0.Beta5</version.resteasy.jaxrs>
-        <version.resteasy>3.0.23.Final</version.resteasy>
+        <version.resteasy.api>3.0.12.Final</version.resteasy.api>
+        <version.resteasy>5.0.4.Final</version.resteasy>
         <version.shrinkwrap>1.2.6</version.shrinkwrap>
         <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>
         <version.tomcat.plugin>2.2</version.tomcat.plugin>

--- a/rts/at/recovery/recovery1/pom.xml
+++ b/rts/at/recovery/recovery1/pom.xml
@@ -60,13 +60,6 @@
             <artifactId>restat-util</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <!-- include resteasy since it provide some utility methods for manipulating HTTP headers -->
-        <dependency>
-          <groupId>org.jboss.resteasy</groupId>
-          <artifactId>resteasy-jaxrs</artifactId>
-          <version>3.0.16.Final</version>
-        </dependency>
-
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>

--- a/rts/at/recovery/recovery2/pom.xml
+++ b/rts/at/recovery/recovery2/pom.xml
@@ -87,12 +87,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-          <groupId>org.jboss.resteasy</groupId>
-          <artifactId>resteasy-jaxrs</artifactId>
-          <version>3.0.16.Final</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
             <version>3.1.0.GA</version>

--- a/rts/at/service/service1/pom.xml
+++ b/rts/at/service/service1/pom.xml
@@ -67,11 +67,6 @@
             <artifactId>restat-util</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-          <groupId>org.jboss.resteasy</groupId>
-          <artifactId>resteasy-jaxrs</artifactId>
-          <version>3.0.16.Final</version>
-        </dependency>
         <!-- Jersey container for running participant services -->
         <dependency>
             <groupId>com.sun.jersey</groupId>

--- a/rts/at/service/service1b/pom.xml
+++ b/rts/at/service/service1b/pom.xml
@@ -81,12 +81,6 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-          <groupId>org.jboss.resteasy</groupId>
-          <artifactId>resteasy-jaxrs</artifactId>
-          <version>3.0.16.Final</version>
-        </dependency>
-
         <!-- JBoss logging -->
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/rts/at/simple/pom.xml
+++ b/rts/at/simple/pom.xml
@@ -81,12 +81,6 @@
       <artifactId>restat-util</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <!-- include resteasy since it provide some utility methods for manipulating HTTP headers -->
-    <dependency>
-      <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-jaxrs</artifactId>
-      <version>3.0.16.Final</version>
-    </dependency>
 
     <!-- JBoss logging -->
     <dependency>

--- a/rts/at/undertow/pom.xml
+++ b/rts/at/undertow/pom.xml
@@ -55,30 +55,14 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-          <groupId>org.jboss.resteasy</groupId>
-          <artifactId>resteasy-jaxrs</artifactId>
-          <version>3.0.16.Final</version>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.narayana.arjunacore</groupId>
             <artifactId>arjunacore</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-            <version>${version.jboss.logging}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.undertow</groupId>
-            <artifactId>undertow-servlet</artifactId>
-            <version>${undertow.io.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.undertow</groupId>
-            <artifactId>undertow-core</artifactId>
-            <version>${undertow.io.version}</version>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-core-spi</artifactId>
+            <version>${version.resteasy}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
@@ -90,6 +74,22 @@
     <build>
         <defaultGoal>package</defaultGoal>
         <plugins>
+	          <plugin>
+		          <groupId>org.codehaus.mojo</groupId>
+		          <artifactId>exec-maven-plugin</artifactId>
+		          <executions>
+		            <execution>
+			            <id>Run Quickstart</id>
+			            <phase>integration-test</phase>
+			            <goals>
+			                <goal>java</goal>
+			            </goals>
+		              <configuration>
+		                <mainClass>org.jboss.narayana.rts.TxnTest</mainClass>
+		              </configuration>
+		            </execution>
+		          </executions>
+	          </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/rts/at/undertow/src/main/java/org/jboss/narayana/rts/TransactionAwareResource.java
+++ b/rts/at/undertow/src/main/java/org/jboss/narayana/rts/TransactionAwareResource.java
@@ -54,7 +54,7 @@ public class TransactionAwareResource {
 
     private static Map<String, String> values = new HashMap<String, String>();
 
-    @ApplicationPath("eg")
+    @ApplicationPath("/")
     public static class ServiceApp extends Application
     {
         @Override

--- a/rts/at/undertow/src/main/java/org/jboss/narayana/rts/TxnHelper.java
+++ b/rts/at/undertow/src/main/java/org/jboss/narayana/rts/TxnHelper.java
@@ -50,7 +50,6 @@ public class TxnHelper {
             response = client.target(txurl).request().post(Entity.entity(new Form(), MediaType.APPLICATION_FORM_URLENCODED_TYPE));
             Set<Link> links = response.getLinks();
 
-            EntityUtils.consume((HttpEntity) response.getEntity());
             if (response.getStatus() != HttpURLConnection.HTTP_CREATED)
                 throw new RuntimeException("beginTxn returned " + response.getStatus());
 
@@ -69,8 +68,6 @@ public class TxnHelper {
                     .request().put(Entity.entity(TxStatusMediaType.TX_COMMITTED, TxMediaType.TX_STATUS_MEDIA_TYPE));
 
             int sc = response.getStatus();
-
-            EntityUtils.consume((HttpEntity) response.getEntity());
 
             if (sc != HttpURLConnection.HTTP_OK)
                 throw new RuntimeException("endTxn returned " + sc);

--- a/rts/lra-examples/lra-jwt/wildfly/client/pom.xml
+++ b/rts/lra-examples/lra-jwt/wildfly/client/pom.xml
@@ -17,17 +17,9 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>${version.resteasy.client}</version>
+            <version>${version.resteasy}</version>
             <scope>compile</scope>
             <exclusions>
-                <exclusion>
-                    <groupId>org.jboss.spec.javax.ws.rs</groupId>
-                    <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jboss.spec.javax.xml.bind</groupId>
-                    <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>org.jboss.spec.javax.annotation</groupId>
                     <artifactId>jboss-annotations-api_1.3_spec</artifactId>
@@ -50,7 +42,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jackson2-provider</artifactId>
-            <version>${version.resteasy.client}</version>
+            <version>${version.resteasy}</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>
@@ -74,13 +66,6 @@
                     <artifactId>jakarta.activation</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxrs</artifactId>
-            <version>${version.resteasy.jaxrs}</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/transactionaldriver/transactionaldriver-and-tomcat/pom.xml
+++ b/transactionaldriver/transactionaldriver-and-tomcat/pom.xml
@@ -30,7 +30,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jackson-provider</artifactId>
+            <artifactId>resteasy-jackson2-provider</artifactId>
             <version>${version.resteasy}</version>
         </dependency>
         <dependency>

--- a/transactionaldriver/transactionaldriver-jpa-and-tomcat/pom.xml
+++ b/transactionaldriver/transactionaldriver-jpa-and-tomcat/pom.xml
@@ -30,7 +30,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jackson-provider</artifactId>
+            <artifactId>resteasy-jackson2-provider</artifactId>
             <version>${version.resteasy}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3668
Update resteasy-jaxrs and resteasy-client to newer version (resteasy-core-spi, resteasy-client-api, resteasy-core and resteasy-client)