### PR TITLE
Jbtm 3699 and jbtm 3724

### DIFF
--- a/ArjunaJTA/object_store/README.md
+++ b/ArjunaJTA/object_store/README.md
@@ -28,9 +28,10 @@ This is achieved by persisting information in an Object Store. Various implement
 to cater for various application requirements.
 
 1. FileStoreExample shows how to change the store type to a file base store but in directory different from the default;
-2. HornetqStoreExample shows how to use the Hornetq journal for transction logging;
+2. HornetqStoreExample shows how to use the Hornetq journal for transaction logging;
 3. VolatileStoreExample shows how to use an unsafe (because it does not persist logs in the event of
    failures and therefore does not support recovery) in-memory log store implementation.
+4. JDBCStoreExample shows how to use a database for persisting transaction logs. This example uses [H2](https://www.h2database.com/).
 
 ## Usage
 
@@ -44,7 +45,10 @@ or to run individual tests using the maven java exec plugin:
 mvn -e compile exec:java -Dexec.mainClass=org.jboss.narayana.jta.quickstarts.VolatileStoreExample
 mvn -e compile exec:java -Dexec.mainClass=org.jboss.narayana.jta.quickstarts.HornetqStoreExample
 mvn -e compile exec:java -Dexec.mainClass=org.jboss.narayana.jta.quickstarts.FileStoreExample
+mvn -e compile exec:java -Dexec.mainClass=org.jboss.narayana.jta.quickstarts.JDBCStoreExample
 ```
+
+The JDBCStore can be configured programmatically or via a properties file. To use the properties file pass the argument `-DUSE_JBOSSTS_PROPERTIES=true` on the command line.
 
 ## Expected output
 
@@ -61,3 +65,23 @@ If you use the run script then you the line "[INFO] BUILD SUCCESS" should appear
 Each example either changes the object store directory or object store type (or both) and then runs a
 transaction. Each example performs a relevant test to verify that the object store type or directory,
 as appropriate, was used.
+
+## Viewing JDBC store logs
+
+The example uses H2 so you could use the H2 console:
+
+mvn dependency:copy-dependencies # download the H2 jar
+java -cp target/dependency/h2-1.4.195.jar org.h2.tools.Server -tcp -web # start the H2 console
+Now use a browser to navigate to the H2 console: http://192.168.0.14:8082/ and enter the appropriate connection parameters:
+
+```
+Driver Class: `org.h2.Driver`
+JDBC URL: `jdbc:h2:~/<quickstart home>/ArjunaJTA/object_store/target/h2/JBTMDB`
+User Name: `sa`
+Password: `sa`
+```
+
+Once connected you may view pending transactions by running the following SQL query: `SELECT * FROM JBOSSTSTXTABLE`
+The table is likely to be empty unless the quickstart crashes between the prepare and commit calls (which you can arrange by either using a IDE with suitable breakpoints or by changing the `DummyXAResource.java` source file to halt the JVM during the commit call).
+
+Note that H2 restricts the number of connections so if you have the console open you can't run the quickstart and vice versa.

--- a/ArjunaJTA/object_store/pom.xml
+++ b/ArjunaJTA/object_store/pom.xml
@@ -35,6 +35,10 @@
   <packaging>jar</packaging>
   <name>Configuring the Object Store</name>
 
+  <properties>
+    <version.com.h2database>1.4.195</version.com.h2database>
+  </properties>
+
   <dependencies>
     <!-- For logging -->
     <dependency>
@@ -46,6 +50,12 @@
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-journal</artifactId>
       <version>2.18.0</version>
+    </dependency>
+    <!-- JDBCStore dependency on h2 -->
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <version>${version.com.h2database}</version>
     </dependency>
   </dependencies>
 

--- a/ArjunaJTA/object_store/run.bat
+++ b/ArjunaJTA/object_store/run.bat
@@ -28,3 +28,6 @@ IF %ERRORLEVEL% NEQ 0 exit -1
 
 mvn -e compile exec:java -Dexec.mainClass=org.jboss.narayana.jta.quickstarts.FileStoreExample %NARAYANA_VERSION_PARAM%
 IF %ERRORLEVEL% NEQ 0 exit -1
+
+mvn -e compile exec:java -Dexec.mainClass=org.jboss.narayana.jta.quickstarts.JDBCStoreExample %NARAYANA_VERSION_PARAM%
+IF %ERRORLEVEL% NEQ 0 exit -1

--- a/ArjunaJTA/object_store/run.sh
+++ b/ArjunaJTA/object_store/run.sh
@@ -38,3 +38,8 @@ mvn -e exec:java -Dexec.mainClass=org.jboss.narayana.jta.quickstarts.FileStoreEx
 if [ "$?" != "0" ]; then
 	exit -1
 fi
+
+mvn -e exec:java -Dexec.mainClass=org.jboss.narayana.jta.quickstarts.JDBCStoreExample $NARAYANA_VERSION_PARAM
+if [ "$?" != "0" ]; then
+	exit -1
+fi

--- a/ArjunaJTA/object_store/src/main/java/org/jboss/narayana/jta/quickstarts/DummyXAResource.java
+++ b/ArjunaJTA/object_store/src/main/java/org/jboss/narayana/jta/quickstarts/DummyXAResource.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The Narayana Authors
+ *
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package org.jboss.narayana.jta.quickstarts;
+
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+import java.io.Serializable;
+
+public class DummyXAResource implements XAResource, Serializable {
+    static final long serialVersionUID = 1;
+
+    public DummyXAResource() {
+    }
+
+    public void commit(final Xid xid, final boolean arg1) throws XAException {
+        System.out.println("DummyXAResource commit() called");
+    }
+
+    public void end(final Xid xid, final int arg1) throws XAException {
+    }
+
+    public void forget(final Xid xid) throws XAException {
+    }
+
+    public int getTransactionTimeout() throws XAException {
+        return 0;
+    }
+
+    public boolean isSameRM(final XAResource arg0) throws XAException {
+        return this.equals(arg0);
+    }
+
+    public int prepare(final Xid xid) throws XAException {
+        return XAResource.XA_OK;
+    }
+
+    public Xid[] recover(final int arg0) throws XAException {
+        return new Xid[0];
+    }
+
+    public void rollback(final Xid xid) throws XAException {
+    }
+
+    public void start(final Xid xid, final int arg1) throws XAException {
+    }
+
+    public boolean setTransactionTimeout(final int arg0) throws XAException {
+        return false;
+    }
+}

--- a/ArjunaJTA/object_store/src/main/java/org/jboss/narayana/jta/quickstarts/JDBCStoreExample.java
+++ b/ArjunaJTA/object_store/src/main/java/org/jboss/narayana/jta/quickstarts/JDBCStoreExample.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright The Narayana Authors
+ *
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package org.jboss.narayana.jta.quickstarts;
+
+import com.arjuna.ats.arjuna.common.MetaObjectStoreEnvironmentBean;
+import com.arjuna.ats.internal.arjuna.objectstore.jdbc.JDBCStore;
+import com.arjuna.ats.internal.arjuna.objectstore.jdbc.accessors.DynamicDataSourceJDBCAccess;
+import com.arjuna.common.internal.util.propertyservice.BeanPopulator;
+import jakarta.transaction.RollbackException;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.TransactionManager;
+import jakarta.transaction.UserTransaction;
+
+public class JDBCStoreExample {
+
+    public static void main(String[] args) throws Exception {
+        // the Narayana transaction store is configurable, set it up to use a database
+        setupStore(Boolean.getBoolean("USE_JBOSSTS_PROPERTIES"));
+
+        UserTransaction utx = com.arjuna.ats.jta.UserTransaction.userTransaction();
+
+        // start a transaction, enlist some resources with it and then commit it
+        utx.begin();
+        enlistResources();
+        utx.commit();
+    }
+
+    public static void enlistResources() throws SystemException, RollbackException {
+        // resource enlistment is performed via the TransactionManager API
+        TransactionManager tm = com.arjuna.ats.jta.TransactionManager.transactionManager();
+        // create two resources, although they won't actually do anything, they will force a log record to be created
+        DummyXAResource xar1 = new DummyXAResource();
+        DummyXAResource xar2 = new DummyXAResource();
+
+        // and enlist them with the transaction
+        tm.getTransaction().enlistResource(xar1);
+        tm.getTransaction().enlistResource(xar2);
+    }
+
+    private static void setupStore(boolean usePropertiesFile) {
+        if (usePropertiesFile) {
+            setupStoreViaPropertiesFile();
+        } else {
+            setupStoreViaConfigBean();
+        }
+    }
+
+    public static void setupStoreViaConfigBean() {
+        final String jdbcStoreClass = JDBCStore.class.getName();
+        final String jdbcAccess = DynamicDataSourceJDBCAccess.class.getName();
+        final String DB_CLASSNAME = "org.h2.jdbcx.JdbcDataSource";
+        final String DB_URL = "jdbc:h2:file:./target/h2/JBTMDB";
+        final String dataSourceJndiName = String.format("%s;ClassName=%s;URL=%s;User=sa;Password=sa",
+                jdbcAccess, DB_CLASSNAME, DB_URL);
+
+        // Narayana uses environment beans to configure the store used to persist transaction logs.
+        // Although it uses various stores for persisting different categories of information
+        // (the default store, stateStore and communicationStore) there is a bean which propagates
+        // config settings to all relevant store config beans:
+        final MetaObjectStoreEnvironmentBean metaObjectStoreEnvironmentBean =
+                BeanPopulator.getDefaultInstance(MetaObjectStoreEnvironmentBean.class);
+
+        // set the store type to the JDBC store
+        metaObjectStoreEnvironmentBean.setObjectStoreType(jdbcStoreClass);
+        // set the JNDI name of the datasource to be  used to access the database
+        metaObjectStoreEnvironmentBean.setJdbcAccess(dataSourceJndiName);
+    }
+
+    public static void setupStoreViaPropertiesFile() {
+        // the same config can be specified using jbossts properties files:
+        if (System.getProperty("com.arjuna.ats.arjuna.common.propertiesFile") == null) {
+            System.setProperty("com.arjuna.ats.arjuna.common.propertiesFile", "h2-jbossts-properties.xml");
+        }
+    }
+}

--- a/ArjunaJTA/object_store/src/main/resources/h2-jbossts-properties.xml
+++ b/ArjunaJTA/object_store/src/main/resources/h2-jbossts-properties.xml
@@ -1,0 +1,12 @@
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+    <!-- the nodeIdentifier must be set (to something) -->
+    <entry key="CoreEnvironmentBean.nodeIdentifier">1</entry>
+    <entry key="ObjectStoreEnvironmentBean.objectStoreType">com.arjuna.ats.internal.arjuna.objectstore.jdbc.JDBCStore</entry>
+    <entry key="ObjectStoreEnvironmentBean.stateStore.objectStoreType">com.arjuna.ats.internal.arjuna.objectstore.jdbc.JDBCStore</entry>
+    <entry key="ObjectStoreEnvironmentBean.communicationStore.objectStoreType">com.arjuna.ats.internal.arjuna.objectstore.jdbc.JDBCStore</entry>
+
+    <entry key="ObjectStoreEnvironmentBean.jdbcAccess">com.arjuna.ats.internal.arjuna.objectstore.jdbc.accessors.DynamicDataSourceJDBCAccess;ClassName=org.h2.jdbcx.JdbcDataSource;URL=jdbc:h2:file:./target/h2/JBTMDB;User=sa;Password=sa</entry>
+    <entry key="ObjectStoreEnvironmentBean.communicationStore.jdbcAccess">com.arjuna.ats.internal.arjuna.objectstore.jdbc.accessors.DynamicDataSourceJDBCAccess;ClassName=org.h2.jdbcx.JdbcDataSource;URL=jdbc:h2:file:./target/h2/JBTMDB;User=sa;Password=sa</entry>
+    <entry key="ObjectStoreEnvironmentBean.stateStore.jdbcAccess">com.arjuna.ats.internal.arjuna.objectstore.jdbc.accessors.DynamicDataSourceJDBCAccess;ClassName=org.h2.jdbcx.JdbcDataSource;URL=jdbc:h2:file:./target/h2/JBTMDB;User=sa;Password=sa</entry>
+</properties>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3724

Add a JDBCStore quickstart.
I want to add this one so that I can refer to it when indicating how LRA can be configured to use a database for its transaction logs.

I have added this directly to my JBTM-3699 tree (see pr #414) to facilitate the merge.

So only the final commit (8f3eaac) is relevant. If I can get PR 414 merged then I can create a PR with just one commit.
