### PR TITLE
Jbtm 3742 fixing false pass

### DIFF
--- a/compensating-transactions/mongodb-simple/README.md
+++ b/compensating-transactions/mongodb-simple/README.md
@@ -20,22 +20,12 @@ it does so in a scalable manor that is compatible with a sharded environment.
 Running the Quickstart
 ----------------------
 
-_NOTE:_ You must have MongoDB installed, prior to running this quickstart. Also, it is assumed your MongoDB instance
-will be running on localhost:27017. If this is not the case, you should update the
-`MongoClient mongo = new MongoClient("localhost", 27017);` line in the AccountManager class, to reflect the actual
-location of your server
+_NOTE:_ Docker is used to instantiate a MongoDB container (the test will automatically carry out all steps needed to create the container).
+Please, make sure that Docker is installed (and configured) in your environment.
 
-_NOTE:_ The quickstart is tested to work with WildFly 8.0.0.Final and Narayana 5.0.0.Final. It should work with newer versions,
-but they are not currently tested.
+_NOTE:_ The quickstart is tested to work with WildFly 28.0.0 and Narayana 6.0. It should work with newer versions, but they are not currently tested.
 
-Console 1
-
-    mongod
-
-Console 2
-
-    mvn clean test
-
+To run the quickstart: `mvn clean test -Parq`
 
 Understanding the Code
 ----------------------

--- a/compensating-transactions/mongodb-simple/pom.xml
+++ b/compensating-transactions/mongodb-simple/pom.xml
@@ -34,8 +34,8 @@
   <description>JBoss Narayana Quickstarts: A simple example of using compensation-based transactions with MongoDB</description>
 
   <properties>
-    <version.testcontainers>1.17.6</version.testcontainers>
     <version.mongodb>3.12.11</version.mongodb>
+    <version.testcontainers>1.17.6</version.testcontainers>
   </properties>
 
   <dependencies>
@@ -101,6 +101,20 @@
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
       <version>${version.jakarta.annotation.api}</version>
+    </dependency>
+
+    <!-- JaxRs API -->
+    <dependency>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+      <version>${version.jakarta.ws.rs-api}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-client</artifactId>
+      <version>${version.resteasy}</version>
+      <scope>provided</scope>
     </dependency>
 
     <!-- Test dependencies -->

--- a/compensating-transactions/mongodb-simple/src/test/java/org/jboss/narayana/quickstarts/mongodb/simple/resources/BankingServiceJaxRs.java
+++ b/compensating-transactions/mongodb-simple/src/test/java/org/jboss/narayana/quickstarts/mongodb/simple/resources/BankingServiceJaxRs.java
@@ -1,0 +1,47 @@
+/*
+ *
+ * Copyright The Narayana Authors
+ *
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ */
+
+package org.jboss.narayana.quickstarts.mongodb.simple.resources;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.jboss.narayana.compensations.api.TransactionCompensatedException;
+import org.jboss.narayana.quickstarts.mongodb.simple.BankingService;
+
+@Path(BankingServiceJaxRs.ROOT_PATH)
+@ApplicationScoped
+public class BankingServiceJaxRs {
+
+    @Inject
+    BankingService bankingService;
+
+    public static final String ROOT_PATH = "banking";
+
+    public static final String TRANSFER_MONEY = "transferMoney";
+
+    @PUT
+    @Path(BankingServiceJaxRs.TRANSFER_MONEY)
+    @Consumes(MediaType.TEXT_PLAIN)
+    public Response transferMoney(
+            @QueryParam("fromAccount") String fromAccount,
+            @QueryParam("toAccount") String toAccount,
+            @QueryParam("amount") double amount) {
+        try {
+            bankingService.transferMoney(fromAccount, toAccount, amount);
+            return Response.ok().build();
+        } catch (TransactionCompensatedException ex) {
+            return Response.serverError().build();
+        }
+    }
+}

--- a/compensating-transactions/mongodb-simple/src/test/java/org/jboss/narayana/quickstarts/mongodb/simple/resources/JaxRsActivator.java
+++ b/compensating-transactions/mongodb-simple/src/test/java/org/jboss/narayana/quickstarts/mongodb/simple/resources/JaxRsActivator.java
@@ -1,0 +1,16 @@
+/*
+ *
+ * Copyright The Narayana Authors
+ *
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ */
+
+package org.jboss.narayana.quickstarts.mongodb.simple.resources;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class JaxRsActivator extends Application {
+}


### PR DESCRIPTION
This PR is a fix for an issue introduced with #424. Although #424 passed all tests, the annotation `@Container` doesn't work very well with `Arquillian`. In fact, the `@Container` annotation was able (somehow) to hide failures happening during the testing phase of this quickstart. To address this "false success", I have changed the way tests are executed: `Arquillian` and `testcontainers` are now executed locally. Please, refer to the code for more details.
