### PR TITLE
[JBTM-3699] rts/at/jta-service/jpa fixed

### DIFF
--- a/rts/at/jta-service/jpa/pom.xml
+++ b/rts/at/jta-service/jpa/pom.xml
@@ -112,7 +112,7 @@
 
         <dependency>
             <groupId>org.jboss.arquillian.protocol</groupId>
-            <artifactId>arquillian-protocol-servlet</artifactId>
+            <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
             <version>${version.org.jboss.arquillian}</version>
             <scope>test</scope>
         </dependency>

--- a/rts/at/jta-service/jpa/src/main/java/org/jboss/narayana/quickstart/rest/bridge/inbound/jpa/jaxrs/TaskResource.java
+++ b/rts/at/jta-service/jpa/src/main/java/org/jboss/narayana/quickstart/rest/bridge/inbound/jpa/jaxrs/TaskResource.java
@@ -36,13 +36,11 @@ import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriInfo;
 
 import jakarta.json.Json;
-import jakarta.json.JsonArray;
 import jakarta.json.JsonArrayBuilder;
-import jakarta.json.JsonObject;
 import org.jboss.narayana.quickstart.rest.bridge.inbound.jpa.model.Task;
 import org.jboss.narayana.quickstart.rest.bridge.inbound.jpa.model.TaskDao;
-import org.jboss.narayana.quickstart.rest.bridge.inbound.jpa.model.User;
-import org.jboss.narayana.quickstart.rest.bridge.inbound.jpa.model.UserDao;
+import org.jboss.narayana.quickstart.rest.bridge.inbound.jpa.model.UserTable;
+import org.jboss.narayana.quickstart.rest.bridge.inbound.jpa.model.UserTableDao;
 
 /**
  * A JAX-RS resource for exposing REST endpoints for Task manipulation
@@ -59,7 +57,7 @@ public class TaskResource {
     public static final String TASKS_PATH_SEGMENT = "tasks";
 
     @EJB
-    private UserDao userDao;
+    private UserTableDao userTableDao;
 
     @EJB
     private TaskDao taskDao;
@@ -75,7 +73,7 @@ public class TaskResource {
     @DELETE
     @Path(USERS_PATH_SEGMENT)
     public void deleteUsers() {
-        userDao.deleteUsers();
+        userTableDao.deleteUsers();
     }
 
     @POST
@@ -84,7 +82,7 @@ public class TaskResource {
     public Response createTask(@Context UriInfo info, @PathParam("username") String username,
             @PathParam("title") String taskTitle) {
 
-        User user = getUser(username);
+        UserTable user = getUser(username);
         Task task = new Task(taskTitle);
 
         taskDao.createTask(user, task);
@@ -101,7 +99,7 @@ public class TaskResource {
     @DELETE
     @Path(TASKS_PATH_SEGMENT + "/{username}/{id}")
     public void deleteTaskById(@PathParam("username") String username, @PathParam("id") Long id) {
-        User user = getUser(username);
+        UserTable user = getUser(username);
         Task task = getTask(user, id);
         taskDao.deleteTask(task);
     }
@@ -116,7 +114,7 @@ public class TaskResource {
     @Path(TASKS_PATH_SEGMENT + "/{username}/{id}")
     @Produces({MediaType.APPLICATION_JSON})
     public String getTaskById(@PathParam("username") String username, @PathParam("id") Long id) {
-        User user = getUser(username);
+        UserTable user = getUser(username);
         return getTask(user, id).toJson().toString();
     }
 
@@ -150,15 +148,15 @@ public class TaskResource {
 
     // Utility Methods
 
-    private List<Task> getTasks(User user, String title) {
+    private List<Task> getTasks(UserTable user, String title) {
         return taskDao.getForTitle(user, title);
     }
 
-    private List<Task> getTasks(User user) {
+    private List<Task> getTasks(UserTable user) {
         return taskDao.getAll(user);
     }
 
-    private Task getTask(User user, Long id) {
+    private Task getTask(UserTable user, Long id) {
         for (Task task : taskDao.getAll(user))
             if (task.getId().equals(id))
                 return task;
@@ -166,14 +164,14 @@ public class TaskResource {
         throw new WebApplicationException(Response.Status.NOT_FOUND);
     }
 
-    private User getUser(String username) {
+    private UserTable getUser(String username) {
         try {
-            User user = userDao.getForUsername(username);
+            UserTable user = userTableDao.getForUsername(username);
 
             if (user == null) {
-                user = new User(username);
+                user = new UserTable(username);
 
-                userDao.createUser(user);
+                userTableDao.createUser(user);
             }
 
             return user;

--- a/rts/at/jta-service/jpa/src/main/java/org/jboss/narayana/quickstart/rest/bridge/inbound/jpa/model/Task.java
+++ b/rts/at/jta-service/jpa/src/main/java/org/jboss/narayana/quickstart/rest/bridge/inbound/jpa/model/Task.java
@@ -43,7 +43,7 @@ public class Task implements Serializable {
     private Long id;
 
     @ManyToOne
-    private User owner;
+    private UserTable owner;
 
     private String title;
 
@@ -63,7 +63,7 @@ public class Task implements Serializable {
         this.id = id;
     }
 
-    public User getOwner() {
+    public UserTable getOwner() {
         return owner;
     }
 
@@ -71,7 +71,7 @@ public class Task implements Serializable {
         return owner.getUsername();
     }
 
-    public void setOwner(User owner) {
+    public void setOwner(UserTable owner) {
         this.owner = owner;
     }
 

--- a/rts/at/jta-service/jpa/src/main/java/org/jboss/narayana/quickstart/rest/bridge/inbound/jpa/model/TaskDao.java
+++ b/rts/at/jta-service/jpa/src/main/java/org/jboss/narayana/quickstart/rest/bridge/inbound/jpa/model/TaskDao.java
@@ -30,13 +30,13 @@ import jakarta.ejb.Local;
 @Local
 public interface TaskDao {
 
-    void createTask(User user, Task task);
+    void createTask(UserTable user, Task task);
 
-    List<Task> getAll(User user);
+    List<Task> getAll(UserTable user);
 
-    List<Task> getRange(User user, int offset, int count);
+    List<Task> getRange(UserTable user, int offset, int count);
 
-    List<Task> getForTitle(User user, String title);
+    List<Task> getForTitle(UserTable user, String title);
 
     void deleteTask(Task task);
     

--- a/rts/at/jta-service/jpa/src/main/java/org/jboss/narayana/quickstart/rest/bridge/inbound/jpa/model/TaskDaoImpl.java
+++ b/rts/at/jta-service/jpa/src/main/java/org/jboss/narayana/quickstart/rest/bridge/inbound/jpa/model/TaskDaoImpl.java
@@ -38,7 +38,7 @@ public class TaskDaoImpl implements TaskDao {
     EntityManager em;
 
     @Override
-    public void createTask(User user, Task task) {
+    public void createTask(UserTable user, Task task) {
         if (!em.contains(user)) {
             user = em.merge(user);
         }
@@ -48,13 +48,13 @@ public class TaskDaoImpl implements TaskDao {
     }
 
     @Override
-    public List<Task> getAll(User user) {
+    public List<Task> getAll(UserTable user) {
         TypedQuery<Task> query = querySelectAllTasksFromUser(user);
         return query.getResultList();
     }
 
     @Override
-    public List<Task> getRange(User user, int offset, int count) {
+    public List<Task> getRange(UserTable user, int offset, int count) {
         TypedQuery<Task> query = querySelectAllTasksFromUser(user);
         query.setMaxResults(count);
         query.setFirstResult(offset);
@@ -62,7 +62,7 @@ public class TaskDaoImpl implements TaskDao {
     }
 
     @Override
-    public List<Task> getForTitle(User user, String title) {
+    public List<Task> getForTitle(UserTable user, String title) {
         String lowerCaseTitle = "%" + title.toLowerCase() + "%";
         return em.createQuery("SELECT t FROM Task t WHERE t.owner = ?1 AND LOWER(t.title) LIKE ?2", Task.class)
                 .setParameter(1, user).setParameter(2, lowerCaseTitle).getResultList();
@@ -81,7 +81,7 @@ public class TaskDaoImpl implements TaskDao {
         em.createQuery("DELETE FROM Task").executeUpdate();
     }
 
-    private TypedQuery<Task> querySelectAllTasksFromUser(User user) {
+    private TypedQuery<Task> querySelectAllTasksFromUser(UserTable user) {
         return em.createQuery("SELECT t FROM Task t WHERE t.owner = ?1", Task.class).setParameter(1, user);
     }
 }

--- a/rts/at/jta-service/jpa/src/main/java/org/jboss/narayana/quickstart/rest/bridge/inbound/jpa/model/UserTable.java
+++ b/rts/at/jta-service/jpa/src/main/java/org/jboss/narayana/quickstart/rest/bridge/inbound/jpa/model/UserTable.java
@@ -30,13 +30,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 
 /**
- * User entity
+ * UserTable entity
  * 
  * @author Oliver Kiss
  */
 @SuppressWarnings("serial")
 @Entity
-public class User implements Serializable {
+public class UserTable implements Serializable {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
@@ -49,10 +49,10 @@ public class User implements Serializable {
     @Column(updatable = false)
     private List<Task> tasks = new ArrayList<Task>();
 
-    public User() {
+    public UserTable() {
     }
 
-    public User(String username) {
+    public UserTable(String username) {
         this.username = username;
     }
 
@@ -96,7 +96,7 @@ public class User implements Serializable {
             return false;
         if (getClass() != obj.getClass())
             return false;
-        User other = (User) obj;
+        UserTable other = (UserTable) obj;
         if (username == null) {
             if (other.username != null)
                 return false;

--- a/rts/at/jta-service/jpa/src/main/java/org/jboss/narayana/quickstart/rest/bridge/inbound/jpa/model/UserTableDao.java
+++ b/rts/at/jta-service/jpa/src/main/java/org/jboss/narayana/quickstart/rest/bridge/inbound/jpa/model/UserTableDao.java
@@ -16,41 +16,21 @@
  */
 package org.jboss.narayana.quickstart.rest.bridge.inbound.jpa.model;
 
-import java.util.List;
-
-import jakarta.ejb.Stateless;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
+import jakarta.ejb.Local;
 
 /**
- * Provides functionality for manipulation with users using persistence context.
+ * Basic operations for manipulation with users
  *
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
  * @author Lukas Fryc
- * @author Oliver Kiss
  *
  */
-@Stateless
-public class UserDaoImpl implements UserDao {
+@Local
+public interface UserTableDao {
 
-    @PersistenceContext
-    EntityManager em;
+    public UserTable getForUsername(String username);
 
-    public User getForUsername(String username) {
-        List<User> result = em.createQuery("select u from User u where u.username = ?1", User.class).setParameter(1, username)
-                .getResultList();
-
-        if (result.isEmpty()) {
-            return null;
-        }
-        return result.get(0);
-    }
-
-    public void createUser(User user) {
-        em.persist(user);
-    }
+    public void createUser(UserTable user);
     
-    public void deleteUsers() {
-        em.createQuery("DELETE FROM User").executeUpdate();
-    }
+    public void deleteUsers();
 }

--- a/rts/at/jta-service/jpa/src/main/java/org/jboss/narayana/quickstart/rest/bridge/inbound/jpa/model/UserTableDaoImpl.java
+++ b/rts/at/jta-service/jpa/src/main/java/org/jboss/narayana/quickstart/rest/bridge/inbound/jpa/model/UserTableDaoImpl.java
@@ -16,21 +16,41 @@
  */
 package org.jboss.narayana.quickstart.rest.bridge.inbound.jpa.model;
 
-import jakarta.ejb.Local;
+import java.util.List;
+
+import jakarta.ejb.Stateless;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 
 /**
- * Basic operations for manipulation with users
+ * Provides functionality for manipulation with users using persistence context.
  *
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
  * @author Lukas Fryc
+ * @author Oliver Kiss
  *
  */
-@Local
-public interface UserDao {
+@Stateless
+public class UserTableDaoImpl implements UserTableDao {
 
-    public User getForUsername(String username);
+    @PersistenceContext
+    EntityManager em;
 
-    public void createUser(User user);
+    public UserTable getForUsername(String username) {
+        List<UserTable> result = em.createQuery("select u from UserTable u where u.username = ?1", UserTable.class).setParameter(1, username)
+                .getResultList();
+
+        if (result.isEmpty()) {
+            return null;
+        }
+        return result.get(0);
+    }
+
+    public void createUser(UserTable user) {
+        em.persist(user);
+    }
     
-    public void deleteUsers();
+    public void deleteUsers() {
+        em.createQuery("DELETE FROM UserTable").executeUpdate();
+    }
 }

--- a/rts/at/jta-service/jpa/src/test/java/org/jboss/narayana/quickstart/rest/bridge/inbound/jpa/test/TaskResourceTest.java
+++ b/rts/at/jta-service/jpa/src/test/java/org/jboss/narayana/quickstart/rest/bridge/inbound/jpa/test/TaskResourceTest.java
@@ -48,12 +48,10 @@ import java.io.File;
  * 
  */
 @RunWith(Arquillian.class)
-@Ignore
-//jakarta TODO: ModuleNotFoundException: org.codehaus.jettison"
 public class TaskResourceTest {
 
     private static final String MANIFEST_STRING = "Manifest-Version: 1.0\n"
-            + "Dependencies: org.jboss.narayana.rts, org.codehaus.jettison\n";
+            + "Dependencies: org.jboss.narayana.rts\n";
 
     private static final String DEPLOYMENT_NAME = "restat-bridge-jpa-test";
 

--- a/rts/at/jta-service/jpa/src/test/resources/arquillian.xml
+++ b/rts/at/jta-service/jpa/src/test/resources/arquillian.xml
@@ -24,8 +24,6 @@
         http://jboss.org/schema/arquillian
         http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
-    <defaultProtocol type="Servlet 3.0"/>
-
     <container qualifier="jbossas-managed" default="true">
         <configuration>
             <property name="javaVmArguments">${modular.jdk.args} ${server.jvm.args}</property>


### PR DESCRIPTION
This PR fixes the quickstart in `rts/at/jta-service/jpa`, which was disabled during the migration to Jakarta because of the exception `ModuleNotFoundException: org.codehaus.jettison`. NB: this PR renames `User` to `UserTable` to eliminate the name conflict that affects H2 (`User` is a reserved table name)