### PR TITLE
Lra-examples migrated to jakarta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,8 +167,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 <!--         quarkus -->
-        <quarkus-plugin.version>2.10.0.Final</quarkus-plugin.version>
-        <quarkus.platform.version>2.12.1.Final</quarkus.platform.version>
+        <quarkus-plugin.version>3.0.0.Alpha1</quarkus-plugin.version>
+        <quarkus.platform.version>3.0.0.Alpha1</quarkus.platform.version>
         
         <server.jvm.args>${jvm.args.other} ${jvm.args.memory} ${jvm.args.debug} ${jvm.args.modular}</server.jvm.args>
         <spring.version>2.0.9.RELEASE</spring.version>

--- a/rts/lra-examples/cdi-embedded/pom.xml
+++ b/rts/lra-examples/cdi-embedded/pom.xml
@@ -136,38 +136,37 @@
     </build>
 
     <profiles>
-<!--     jakarta TODO: restore profile and fix Error: Could not find or load main class io.quarkus.bootstrap.runner.QuarkusEntryPoint -->
-<!--         <profile> -->
-<!--             <id>unix</id> -->
-<!--             <activation> -->
-<!--                 <os> -->
-<!--                     <family>unix</family> -->
-<!--                 </os> -->
-<!--                 <property> -->
-<!--                     <name>!skipTests</name> -->
-<!--                 </property> -->
-<!--             </activation> -->
-<!--             <build> -->
-<!--                 <plugins> -->
-<!--                     <plugin> -->
-<!--                         <groupId>org.codehaus.mojo</groupId> -->
-<!--                         <artifactId>exec-maven-plugin</artifactId> -->
-<!--                         <executions> -->
-<!--                             <execution> -->
-<!--                                 <id>Run Quickstart</id> -->
-<!--                                 <phase>integration-test</phase> -->
-<!--                                 <goals> -->
-<!--                                     <goal>exec</goal> -->
-<!--                                 </goals> -->
-<!--                                 <configuration> -->
-<!--                                     <executable>bash</executable> -->
-<!--                                     <commandlineArgs>${basedir}/../run.sh</commandlineArgs> -->
-<!--                                 </configuration> -->
-<!--                             </execution> -->
-<!--                         </executions> -->
-<!--                     </plugin> -->
-<!--                 </plugins> -->
-<!--             </build> -->
-<!--         </profile> -->
+         <profile>
+             <id>unix</id>
+             <activation>
+                 <os>
+                     <family>unix</family>
+                 </os>
+                 <property>
+                     <name>!skipTests</name>
+                 </property>
+             </activation>
+             <build>
+                 <plugins>
+                     <plugin>
+                         <groupId>org.codehaus.mojo</groupId>
+                         <artifactId>exec-maven-plugin</artifactId>
+                         <executions>
+                             <execution>
+                                 <id>Run Quickstart</id>
+                                 <phase>integration-test</phase>
+                                 <goals>
+                                     <goal>exec</goal>
+                                 </goals>
+                                 <configuration>
+                                     <executable>bash</executable>
+                                     <commandlineArgs>${basedir}/../run.sh</commandlineArgs>
+                                 </configuration>
+                             </execution>
+                         </executions>
+                     </plugin>
+                 </plugins>
+             </build>
+         </profile>
     </profiles>
 </project>

--- a/rts/lra-examples/cdi-participant/pom.xml
+++ b/rts/lra-examples/cdi-participant/pom.xml
@@ -134,39 +134,37 @@
         </dependency>
     </dependencies>
     <profiles>
-    
-<!--     jakarta TODO: restore profile and fix NoClassDefFoundError: javax/annotation/Priority -->
-<!--         <profile> -->
-<!--             <id>unix</id> -->
-<!--             <activation> -->
-<!--                 <os> -->
-<!--                     <family>unix</family> -->
-<!--                 </os> -->
-<!--                 <property> -->
-<!--                     <name>!skipTests</name> -->
-<!--                 </property> -->
-<!--             </activation> -->
-<!--             <build> -->
-<!--                 <plugins> -->
-<!--                     <plugin> -->
-<!--                         <groupId>org.codehaus.mojo</groupId> -->
-<!--                         <artifactId>exec-maven-plugin</artifactId> -->
-<!--                         <executions> -->
-<!--                             <execution> -->
-<!--                                 <id>Run Quickstart</id> -->
-<!--                                 <phase>integration-test</phase> -->
-<!--                                 <goals> -->
-<!--                                     <goal>exec</goal> -->
-<!--                                 </goals> -->
-<!--                                 <configuration> -->
-<!--                                     <executable>bash</executable> -->
-<!--                                     <commandlineArgs>${basedir}/../run.sh</commandlineArgs> -->
-<!--                                 </configuration> -->
-<!--                             </execution> -->
-<!--                         </executions> -->
-<!--                     </plugin> -->
-<!--                 </plugins> -->
-<!--             </build> -->
-<!--         </profile> -->
+         <profile>
+             <id>unix</id>
+             <activation>
+                 <os>
+                     <family>unix</family>
+                 </os>
+                 <property>
+                     <name>!skipTests</name>
+                 </property>
+             </activation>
+             <build>
+                 <plugins>
+                     <plugin>
+                         <groupId>org.codehaus.mojo</groupId>
+                         <artifactId>exec-maven-plugin</artifactId>
+                         <executions>
+                             <execution>
+                                 <id>Run Quickstart</id>
+                                 <phase>integration-test</phase>
+                                 <goals>
+                                     <goal>exec</goal>
+                                 </goals>
+                                 <configuration>
+                                     <executable>bash</executable>
+                                     <commandlineArgs>${basedir}/../run.sh</commandlineArgs>
+                                 </configuration>
+                             </execution>
+                         </executions>
+                     </plugin>
+                 </plugins>
+             </build>
+         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
This PR resolves the following two problems (which came up during the migration to Jakarta) in the quickstart `lra-examples`:
* restore profile and fix NoClassDefFoundError: javax/annotation/Priority
* restore profile and fix Error: Could not find or load main class io.quarkus.bootstrap.runner.QuarkusEntryPoint