### PR TITLE
[JBTM-3699] change of path in run.sh for the quickstart lra-examples

### DIFF
--- a/rts/lra-examples/run.sh
+++ b/rts/lra-examples/run.sh
@@ -47,14 +47,6 @@ function killpid {
   test $? || echo "===== could not kill $1"
 }
 
-function start_coordinator {
-  echo "===== starting external coordinator on port ${coord_port}"
-  JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"
-  java ${JAVA_OPTS} ${IP_OPTS} -jar ../lra-coordinator/target/lra-coordinator-quarkus.jar &
-  coord_pid=$!
-  sleep `timeout_adjust 10 2>/dev/null || echo 10`
-}
-
 function start_service {
   echo "===== starting service on port ${service_port}"
   if test -f "target/${quarkusjar}"; then
@@ -126,7 +118,7 @@ if [[ "$last" = "participant" ]]; then
 #  start_coordinator
   echo "===== starting external coordinator on port ${coord_port}"
   JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"
-  java ${JAVA_OPTS} ${IP_OPTS} -jar ../lra-coordinator/target/lra-coordinator-quarkus.jar &
+  java ${JAVA_OPTS} ${IP_OPTS} -jar $PWD/../lra-coordinator/target/lra-coordinator-quarkus.jar &
   coord_pid=$!
   sleep `timeout_adjust 10 2>/dev/null || echo 10`
 elif [[ "$last" = "embedded" ]]; then


### PR DESCRIPTION
Our CI doesn't like relative paths. This PR is the workaround. I already [tested](https://ci-jenkins-csb-narayana.apps.ocp-c1.prod.psi.redhat.com/job/narayana_6.0-quickstarts/7/) this PR (the quickstart with MongoDB fails because there isn't any docker/podman environment in our CI)
