### PR TITLE
Disable mongodb quickstart

### DIFF
--- a/compensating-transactions/pom.xml
+++ b/compensating-transactions/pom.xml
@@ -36,7 +36,10 @@
   <modules>
     <module>non-transactional_resource</module>
     <module>travel-agent</module>
-    <module>mongodb-simple</module>
+<!-- The mongodb-simple quickstart works but requires docker to run MongoDB. -->
+<!-- We have disabled it because our Jenkins infrastructure does not have docker installed. -->
+<!-- But you can run the quickstart by following the instructions in the [README](README.md). -->
+<!--     <module>mongodb-simple</module> -->
   </modules>
 
   <properties>


### PR DESCRIPTION
Until our CI will not be able to manage quickstarts using docker we want those quickstarts to be disabled. In fact those quickstarts might work locally but not yet on our CI infrastructure. 
Additionally we don't want those quickstarts' errors to influence contributors' PRs test result.