### PR TITLE
quarkus update to 3.4.2

### DIFF
--- a/ArjunaJTA/object_store/pom.xml
+++ b/ArjunaJTA/object_store/pom.xml
@@ -21,9 +21,9 @@
   <dependencies>
     <!-- For logging -->
     <dependency>
-       <groupId>org.wildfly.core</groupId>
-       <artifactId>wildfly-logging</artifactId>
-       <version>5.0.0.Beta5</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.activemq</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -151,8 +151,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!--         quarkus -->
-        <quarkus-plugin.version>3.0.1.Final</quarkus-plugin.version>
-        <quarkus.platform.version>3.0.1.Final</quarkus.platform.version>
+        <quarkus-plugin.version>3.4.2</quarkus-plugin.version>
+        <quarkus.platform.version>3.4.2</quarkus.platform.version>
 
         <server.jvm.args>${jvm.args.other} ${jvm.args.memory} ${jvm.args.debug} ${jvm.args.modular}</server.jvm.args>
         <spring.version>2.0.9.RELEASE</spring.version>

--- a/rts/at/annotation/flight-service/pom.xml
+++ b/rts/at/annotation/flight-service/pom.xml
@@ -28,7 +28,7 @@
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <version>${version.quarkus}</version>
+        <version>${quarkus-plugin.version}</version>
         <configuration>
           <debug>5006</debug>
         </configuration>

--- a/rts/at/annotation/hotel-service/pom.xml
+++ b/rts/at/annotation/hotel-service/pom.xml
@@ -27,7 +27,7 @@
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <version>${version.quarkus}</version>
+        <version>${quarkus-plugin.version}</version>
         <configuration>
           <debug>5007</debug>
         </configuration>

--- a/rts/at/annotation/pom.xml
+++ b/rts/at/annotation/pom.xml
@@ -17,15 +17,12 @@
     <module>trip-service</module>
   </modules>
 
-  <properties>
-    <version.quarkus>3.0.0.Alpha5</version.quarkus>
-  </properties>
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bom</artifactId>
-        <version>${version.quarkus}</version>
+        <version>${quarkus.platform.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/rts/at/annotation/trip-service/pom.xml
+++ b/rts/at/annotation/trip-service/pom.xml
@@ -27,7 +27,7 @@
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <version>${version.quarkus}</version>
+        <version>${quarkus-plugin.version}</version>
         <configuration>
           <debug>5008</debug>
         </configuration>


### PR DESCRIPTION
Update quarkus to 3.4.2 version

This PR will be on hold until https://github.com/jbosstm/narayana/pull/2177 get merged.

Note: I added an extra commit in order to fix the failure shown in [CI build](https://ci-jenkins-csb-narayana.apps.ocp-c1.prod.psi.redhat.com/job/btny-pulls-narayana-quickstart/17/)
