### PR TITLE
dependency jboss-logging needed in some quickstarts

### DIFF
--- a/ArjunaCore/txoj/pom.xml
+++ b/ArjunaCore/txoj/pom.xml
@@ -48,6 +48,10 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging</artifactId>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>

--- a/ArjunaJTA/jakarta_transaction/pom.xml
+++ b/ArjunaJTA/jakarta_transaction/pom.xml
@@ -14,6 +14,12 @@
   <artifactId>jakarta_transaction</artifactId>
   <packaging>jar</packaging>
   <name>Jakarta Transaction Examples</name>
+  <dependencies>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging</artifactId>
+    </dependency>
+  </dependencies>
   <build>
     <plugins>
       <!-- This plugin allows our example to be executed by maven -->

--- a/ArjunaJTA/object_store/pom.xml
+++ b/ArjunaJTA/object_store/pom.xml
@@ -31,6 +31,10 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-journal</artifactId>
     </dependency>


### PR DESCRIPTION
Dependency jboss-logging is needed in order to fix errors shown in build: https://ci-jenkins-csb-narayana.apps.ocp-c1.prod.psi.redhat.com/job/narayana-quickstarts/jdk=openJDK17,label=jnlp-agent/143/console 