### PR TITLE
[JBTM-3850] Disable not working XTS/ssl quickstart

### DIFF
--- a/XTS/pom.xml
+++ b/XTS/pom.xml
@@ -17,7 +17,8 @@
     <module>raw-xts-api-demo</module>
     <module>wsat-jta-multi_service</module>
     <module>wsat-jta-multi_hop</module>
-    <module>ssl</module>
+<!--    to enable ssl see https://issues.redhat.com/browse/JBTM-3851-->
+<!--    <module>ssl</module>-->
   </modules>
 
   <properties>

--- a/XTS/ssl/README.md
+++ b/XTS/ssl/README.md
@@ -1,3 +1,7 @@
+*Please notice that this quickstart is disabled and does not work since the needed wildfly/quickstart 'wsat-simple' has been removed from main branch (see https://issues.redhat.com/browse/WFLY-18515).*
+
+Please feel free to contribute to the update of this quickstart working on https://issues.redhat.com/browse/JBTM-3851
+
 # How to configure WildFly and XTS to use SSL
 
 This example walks you through the steps required to setup two servers (client and server) that communicate via Web services over a secure connection.


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3850

Parent issue is https://issues.redhat.com/browse/JBTM-3849 

related to https://issues.redhat.com/browse/WFLY-18515

This quickstart will be disabled until https://issues.redhat.com/browse/JBTM-3851

Since the wsat-simple has been removed from wildfly/quickstart the ssl quickstart doesn't work anymore, so disabling it.