### PR TITLE
[JBTM-3864] Compensation is removed from WildFly

### DIFF
--- a/compensating-transactions/travel-agent/pom.xml
+++ b/compensating-transactions/travel-agent/pom.xml
@@ -156,7 +156,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <version>${version.surefire.plugin}</version>
             <configuration>
-              <skip>false</skip>
+              <skip>true</skip>
               <systemPropertyVariables combine.children="append">
                 <!-- Used in arquillian.xml -->
                 <server.jvm.args>${jvm.args.other} ${jvm.args.memory} ${jvm.args.debug}</server.jvm.args>
@@ -188,7 +188,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <version>${version.surefire.plugin}</version>
             <configuration>
-              <skip>false</skip>
+              <skip>true</skip>
               <argLine>${ipv6.server.jvm.args}</argLine>
               <systemPropertyVariables combine.children="append">
                 <!-- Used in arquillian.xml -->


### PR DESCRIPTION
partially solve: https://issues.redhat.com/browse/JBTM-3864 

I disabled not working arq test from compensation quickstart, I am OK with removing it if not necessary anymore.

Related to https://github.com/jbosstm/narayana/pull/2233