### PR TITLE
Build 6.0 against JDK 21 

### DIFF
--- a/XTS/raw-xts-api-demo/core/pom.xml
+++ b/XTS/raw-xts-api-demo/core/pom.xml
@@ -26,6 +26,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.jboss.narayana.xts</groupId>
+      <artifactId>ws-t11</artifactId>
+      <classifier>api</classifier>
+    </dependency>
+    <dependency>
       <groupId>jakarta.platform</groupId>
       <artifactId>jakarta.jakartaee-api</artifactId>
       <version>9.1.0</version>

--- a/compensating-transactions/travel-agent/pom.xml
+++ b/compensating-transactions/travel-agent/pom.xml
@@ -47,6 +47,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jboss.narayana.xts</groupId>
+      <artifactId>ws-t11</artifactId>
+      <classifier>api</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.narayana.jta</groupId>
       <artifactId>narayana-jta</artifactId>
       <version>${project.version}</version>

--- a/jta-and-hibernate-standalone/pom.xml
+++ b/jta-and-hibernate-standalone/pom.xml
@@ -145,25 +145,21 @@
             <groupId>org.jboss.byteman</groupId>
             <artifactId>byteman</artifactId>
             <scope>test</scope>
-            <version>${version.byteman}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.byteman</groupId>
             <artifactId>byteman-submit</artifactId>
             <scope>test</scope>
-            <version>${version.byteman}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.byteman</groupId>
             <artifactId>byteman-install</artifactId>
             <scope>test</scope>
-            <version>${version.byteman}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.byteman</groupId>
             <artifactId>byteman-bmunit</artifactId>
             <scope>test</scope>
-            <version>${version.byteman}</version>
         </dependency>
       </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,6 @@
         <!--         arquillian -->
         <version.arquillian.byteman>1.1.0</version.arquillian.byteman>
 
-        <version.byteman>4.0.19</version.byteman>
         <version.clear.plugin>3.0.0</version.clear.plugin>
         <version.com.github.fungal>0.11.0.Final</version.com.github.fungal>
         <version.commons-dbcp2>2.2.0</version.commons-dbcp2>

--- a/transactionaldriver/transactionaldriver-standalone/pom.xml
+++ b/transactionaldriver/transactionaldriver-standalone/pom.xml
@@ -46,7 +46,6 @@
         <dependency>
             <groupId>org.jboss.byteman</groupId>
             <artifactId>byteman-bmunit</artifactId>
-            <version>${version.byteman}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/wildfly/commit-markable-resource/pom.xml
+++ b/wildfly/commit-markable-resource/pom.xml
@@ -119,13 +119,11 @@
         <dependency>
             <groupId>org.jboss.byteman</groupId>
             <artifactId>byteman</artifactId>
-            <version>${version.byteman}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.byteman</groupId>
             <artifactId>byteman-submit</artifactId>
-            <version>${version.byteman}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This PR includes commit from JBTM-3870, which upgrades byteman dependency.

 note: ws-t11 dependency needs the 'api' classifier.