### PR TITLE
Quarkus update to 3.17.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,8 +147,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!--         quarkus -->
-        <quarkus-plugin.version>3.8.6</quarkus-plugin.version>
-        <quarkus.platform.version>3.8.6</quarkus.platform.version>
+        <quarkus-plugin.version>3.17.5</quarkus-plugin.version>
+        <quarkus.platform.version>3.17.5</quarkus.platform.version>
 
         <server.jvm.args>${jvm.args.other} ${jvm.args.memory} ${jvm.args.debug} ${jvm.args.modular}</server.jvm.args>
         <spring.version>2.0.9.RELEASE</spring.version>

--- a/rts/at/annotation/pom.xml
+++ b/rts/at/annotation/pom.xml
@@ -31,7 +31,7 @@
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-rest-client</artifactId>
+      <artifactId>quarkus-resteasy-client</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/rts/lra-examples/cdi-embedded/pom.xml
+++ b/rts/lra-examples/cdi-embedded/pom.xml
@@ -77,7 +77,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-jackson</artifactId>
+            <artifactId>quarkus-resteasy-client-jackson</artifactId>
         </dependency>
         
         <dependency>

--- a/rts/lra-examples/cdi-participant/pom.xml
+++ b/rts/lra-examples/cdi-participant/pom.xml
@@ -108,7 +108,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-jackson</artifactId>
+            <artifactId>quarkus-resteasy-client-jackson</artifactId>
         </dependency>
         <dependency>
           <groupId>org.jboss.narayana.lra</groupId>

--- a/rts/lra-examples/coordinator-quarkus/pom.xml
+++ b/rts/lra-examples/coordinator-quarkus/pom.xml
@@ -35,7 +35,7 @@
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-rest-client</artifactId>
+      <artifactId>quarkus-resteasy-client</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Update quarkus to 3.17.5

Since Quarkus 3.9.x Quarkus rest default is resteasy reactive  (see https://quarkus.io/guides/rest-migration).

Since  Narayana LRA is a servlet-based JAX-RS it is not possible to move now to  Quarkus resteasy reactive, which is the default choice, is not feasible at the moment (see https://quarkus.io/guides/rest-migration#servlets). So we need to stick with reasteasy classic for the moment.

cc @mmusgrov @tomjenkinson 