### PR TITLE
JBTM-3965 Allways enlist participants

### DIFF
--- a/ArjunaJTA/object_store/src/main/java/org/jboss/narayana/jta/quickstarts/FileStoreExample.java
+++ b/ArjunaJTA/object_store/src/main/java/org/jboss/narayana/jta/quickstarts/FileStoreExample.java
@@ -16,6 +16,7 @@ public class FileStoreExample {
         UserTransaction utx = com.arjuna.ats.jta.UserTransaction.userTransaction();
 
         utx.begin();
+        Util.enlistResources();
         utx.commit();
 
         if (!new File(storeDir).exists())

--- a/ArjunaJTA/object_store/src/main/java/org/jboss/narayana/jta/quickstarts/HornetqStoreExample.java
+++ b/ArjunaJTA/object_store/src/main/java/org/jboss/narayana/jta/quickstarts/HornetqStoreExample.java
@@ -18,6 +18,7 @@ public class HornetqStoreExample {
         UserTransaction utx = com.arjuna.ats.jta.UserTransaction.userTransaction();
 
         utx.begin();
+        Util.enlistResources();
         utx.commit();
 
 		shutdownStore();

--- a/ArjunaJTA/object_store/src/main/java/org/jboss/narayana/jta/quickstarts/JDBCStoreExample.java
+++ b/ArjunaJTA/object_store/src/main/java/org/jboss/narayana/jta/quickstarts/JDBCStoreExample.java
@@ -19,20 +19,8 @@ public class JDBCStoreExample {
 
         // start a transaction, enlist some resources with it and then commit it
         utx.begin();
-        enlistResources();
+        Util.enlistResources();
         utx.commit();
-    }
-
-    public static void enlistResources() throws SystemException, RollbackException {
-        // resource enlistment is performed via the TransactionManager API
-        TransactionManager tm = com.arjuna.ats.jta.TransactionManager.transactionManager();
-        // create two resources, although they won't actually do anything, they will force a log record to be created
-        DummyXAResource xar1 = new DummyXAResource();
-        DummyXAResource xar2 = new DummyXAResource();
-
-        // and enlist them with the transaction
-        tm.getTransaction().enlistResource(xar1);
-        tm.getTransaction().enlistResource(xar2);
     }
 
     private static void setupStore(boolean usePropertiesFile) {

--- a/ArjunaJTA/object_store/src/main/java/org/jboss/narayana/jta/quickstarts/Util.java
+++ b/ArjunaJTA/object_store/src/main/java/org/jboss/narayana/jta/quickstarts/Util.java
@@ -5,6 +5,10 @@ import java.io.File;
 import com.arjuna.ats.arjuna.common.ObjectStoreEnvironmentBean;
 import com.arjuna.common.internal.util.propertyservice.BeanPopulator;
 
+import jakarta.transaction.RollbackException;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.TransactionManager;
+
 public class Util {
     public static void emptyObjectStore() {
         String objectStoreDirName = BeanPopulator.getDefaultInstance(ObjectStoreEnvironmentBean.class).getObjectStoreDir();
@@ -38,5 +42,17 @@ public class Util {
 
         if (directory != null)
             directory.delete();
+    }
+
+    public static void enlistResources() throws SystemException, RollbackException {
+        // resource enlistment is performed via the TransactionManager API
+        TransactionManager tm = com.arjuna.ats.jta.TransactionManager.transactionManager();
+        // create two resources, although they won't actually do anything, they will force a log record to be created
+        DummyXAResource xar1 = new DummyXAResource();
+        DummyXAResource xar2 = new DummyXAResource();
+
+        // and enlist them with the transaction
+        tm.getTransaction().enlistResource(xar1);
+        tm.getTransaction().enlistResource(xar2);
     }
 }

--- a/ArjunaJTA/object_store/src/main/java/org/jboss/narayana/jta/quickstarts/VolatileStoreExample.java
+++ b/ArjunaJTA/object_store/src/main/java/org/jboss/narayana/jta/quickstarts/VolatileStoreExample.java
@@ -16,6 +16,7 @@ public class VolatileStoreExample {
         UserTransaction utx = com.arjuna.ats.jta.UserTransaction.userTransaction();
 
         utx.begin();
+        Util.enlistResources();
         utx.commit();
 
         if (new File(defaultStoreDir).exists())


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3965

The object_store quickstart needs to add records to the store for all store types (as it's coded only the JDBC store does so).