### PR TITLE
Quarkus to 3.8.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,8 +147,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!--         quarkus -->
-        <quarkus-plugin.version>3.4.2</quarkus-plugin.version>
-        <quarkus.platform.version>3.4.2</quarkus.platform.version>
+        <quarkus-plugin.version>3.8.6</quarkus-plugin.version>
+        <quarkus.platform.version>3.8.6</quarkus.platform.version>
 
         <server.jvm.args>${jvm.args.other} ${jvm.args.memory} ${jvm.args.debug} ${jvm.args.modular}</server.jvm.args>
         <spring.version>2.0.9.RELEASE</spring.version>


### PR DESCRIPTION
Update Quarkus to 3.8 which is a LTS.

A follow up PR will update Quarkus to 3.15 LTS or higher, see https://github.com/jbosstm/quickstart/pull/470