### PR TITLE
Updating the JMS recovery

### DIFF
--- a/ArjunaJTA/recovery/pom.xml
+++ b/ArjunaJTA/recovery/pom.xml
@@ -24,23 +24,21 @@
       <version>2.44.0</version>
     </dependency>
     <dependency>
+      <groupId>jakarta.jms</groupId>
+      <artifactId>jakarta.jms-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.logging</groupId>
       <artifactId>jboss-logging</artifactId>
-      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <scope>runtime</scope>
+      <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-all</artifactId>
-      <version>5.0.0.Alpha2</version>
-    </dependency>
-    <dependency>
-      <groupId>jakarta.jms</groupId>
-      <artifactId>jakarta.jms-api</artifactId>
+      <groupId>org.jboss.narayana.jta</groupId>
+      <artifactId>jta</artifactId>
     </dependency>
   </dependencies>
 

--- a/ArjunaJTA/recovery/run.bat
+++ b/ArjunaJTA/recovery/run.bat
@@ -2,7 +2,7 @@
 
 echo "Running recovery quickstart"
 
-IF NOT %QUICKSTART_NARAYANA_VERSION%x == x SET NARAYANA_VERSION_PARAM="-Dversion.narayana=${QUICKSTART_NARAYANA_VERSION}"
+IF NOT %QUICKSTART_NARAYANA_VERSION%x == x SET NARAYANA_VERSION_PARAM="-Dversion.narayana=%QUICKSTART_NARAYANA_VERSION%"
 
 rem To run an example use the maven java exec pluging. For example to run the second recovery example
 rem (need to run with cmd /c as mvn exec:java does not fork the process and the failure ends the current bat process)

--- a/ArjunaJTA/recovery/run.sh
+++ b/ArjunaJTA/recovery/run.sh
@@ -29,8 +29,8 @@ mvn -e exec:java -Dexec.mainClass=org.jboss.narayana.jta.quickstarts.recovery.Jm
 #fi
 mvn -e exec:java -Dexec.mainClass=org.jboss.narayana.jta.quickstarts.recovery.JmsRecovery -Dexec.args="-r" $NARAYANA_VERSION_PARAM
 if [ "$?" != "0" ]; then
-	exit -1
     echo "JMS example failed"
+	exit -1
 else
     echo "JMS example succeeded"
 fi

--- a/ArjunaJTA/recovery/src/main/java/org/jboss/narayana/jta/quickstarts/recovery/JmsRecovery.java
+++ b/ArjunaJTA/recovery/src/main/java/org/jboss/narayana/jta/quickstarts/recovery/JmsRecovery.java
@@ -1,8 +1,5 @@
 package org.jboss.narayana.jta.quickstarts.recovery;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 
@@ -18,12 +15,11 @@ import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactor
 import org.apache.activemq.artemis.core.server.JournalType;
 import org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
-import org.apache.activemq.artemis.service.extensions.xa.recovery.ActiveMQXAResourceRecovery;
 import org.jboss.narayana.jta.quickstarts.util.DummyXAResource;
 import org.jboss.narayana.jta.quickstarts.util.Util;
 
-import com.arjuna.ats.jta.common.JTAEnvironmentBean;
-import com.arjuna.common.internal.util.propertyservice.BeanPopulator;
+import com.arjuna.ats.internal.jta.recovery.arjunacore.XARecoveryModule;
+import com.arjuna.ats.jta.recovery.XAResourceRecoveryHelper;
 
 import jakarta.jms.JMSException;
 import jakarta.jms.MessageConsumer;
@@ -54,7 +50,6 @@ public class JmsRecovery extends RecoverySetup {
                 if (args[0].equals("-f")) {
                     new JmsRecovery().testXAWithErrorPart1();
                 } else if (args[0].equals("-r")) {
-                    startRecovery();
                     new JmsRecovery().testXAWithErrorPart2();
                 } else {
                     printErrorMessage();
@@ -106,24 +101,22 @@ public class JmsRecovery extends RecoverySetup {
     }
 
     public static void startRecovery() {
-        String resourceRecoveryClass = ActiveMQXAResourceRecovery.class.getName();
-        String inVMResourceRecoveryOpts = InVMConnectorFactory.class.getName();
-        String remoteResourceRecoveryOpts = NettyConnectorFactory.class.getName();
-
-        /*
-         * Tell JBossTS how to recover Hornetq resources. To do it via jbossts-properties.xml use
-         *  <entry key="JTAEnvironmentBean.xaResourceRecoveryClassNames">
-         */
-        List<String> recoveryClassNames = new ArrayList<String>();
-
-        if (inVM)
-            recoveryClassNames.add(resourceRecoveryClass + ";" + inVMResourceRecoveryOpts);
-        else
-            recoveryClassNames.add(resourceRecoveryClass + ";" + remoteResourceRecoveryOpts);
-
-        BeanPopulator.getDefaultInstance(JTAEnvironmentBean.class).setXaResourceRecoveryClassNames(recoveryClassNames);
-
         RecoverySetup.startRecovery();
+
+        XARecoveryModule xaRecoveryModule = XARecoveryModule.getRegisteredXARecoveryModule();
+        xaRecoveryModule.addXAResourceRecoveryHelper(new XAResourceRecoveryHelper() {
+            @Override
+            public boolean initialise(String p) {
+                return true;
+            }
+
+            @Override
+            public XAResource[] getXAResources() throws Exception {
+                XAConnection xaConnection = xacf.createXAConnection();
+                XASession xaSession = xaConnection.createXASession();
+                return new XAResource[]{xaSession.getXAResource()};
+            }
+        });
     }
 
     private static void startActiveMQServer(String acceptorName, String connFacName) throws Exception {
@@ -152,7 +145,8 @@ public class JmsRecovery extends RecoverySetup {
     private static void initialiseActiveMQClient(String connFacName) {
         xacf = ActiveMQJMSClient.createConnectionFactoryWithoutHA(JMSFactoryType.XA_CF,
                 new TransportConfiguration(connFacName));
-        try (Session s = xacf.createConnection().createSession()) {
+        try (jakarta.jms.Connection conn = xacf.createConnection();
+             Session s = conn.createSession()) {
             queue = s.createQueue("TestQueue");
         } catch (Exception e) {
             e.printStackTrace();
@@ -181,26 +175,23 @@ public class JmsRecovery extends RecoverySetup {
             tm.rollback();
     }
 
-    private void produceMessages(XAConnection connection, String... msgs) throws Exception {
-        // Create an XA session and a message producer
-        try(Session session = connection.createXASession();
-                MessageProducer producer = session.createProducer(queue);){
+    private void produceMessages(Session session, String... msgs) throws Exception {
+        try (MessageProducer producer = session.createProducer(queue)) {
             for (String msg : msgs)
                 producer.send(session.createTextMessage(msg));
         }
     }
 
     public void produceMessages(DummyXAResource.faultType fault, String... messages) throws Exception {
-        try(XAConnection connection = xacf.createXAConnection();) {
+        try (XAConnection connection = xacf.createXAConnection()) {
             connection.start();
 
-            // Begin some Transaction work
             XASession xaSession = connection.createXASession();
             XAResource xaRes = xaSession.getXAResource();
 
-            startJTATx(new DummyXAResource(fault), xaRes);
+            startJTATx(xaRes, new DummyXAResource(fault));
 
-            produceMessages(connection, messages);
+            produceMessages(xaSession, messages);
 
             endJTATx(true);
         }
@@ -231,11 +222,9 @@ public class JmsRecovery extends RecoverySetup {
 
             startJTATx(xaRes, new DummyXAResource(DummyXAResource.faultType.NONE));
 
-            // consume 2 messages withing a transaction
+            // consume messages within a transaction
             msgCnt = consumeMessages(xaConsumer, millis, cnt);
 
-            // roll back the transaction - since we consumed the messages inside a
-            // transaction they should still be available
             endJTATx(true);
         }
 
@@ -267,6 +256,7 @@ public class JmsRecovery extends RecoverySetup {
     }
 
     public void testXAWithErrorPart2() throws Exception {
+        runRecoveryScan();
         runRecoveryScan();
         int cnt = consumeMessages(2, 500);
         if (cnt != 2)

--- a/ArjunaJTA/recovery/src/main/java/org/jboss/narayana/jta/quickstarts/recovery/RecoverySetup.java
+++ b/ArjunaJTA/recovery/src/main/java/org/jboss/narayana/jta/quickstarts/recovery/RecoverySetup.java
@@ -13,9 +13,8 @@ public class RecoverySetup {
 
     public static void startRecovery() {
         BeanPopulator.getDefaultInstance(ObjectStoreEnvironmentBean.class).setObjectStoreDir(Util.recoveryStoreDir);
-        RecoveryManager.delayRecoveryManagerThread() ;
         BeanPopulator.getDefaultInstance(RecoveryEnvironmentBean.class).setRecoveryBackoffPeriod(1);
-        recoveryManager = RecoveryManager.manager();
+        recoveryManager = RecoveryManager.manager(RecoveryManager.DIRECT_MANAGEMENT);
     }
 
     public static void stopRecovery() {

--- a/ArjunaJTA/recovery/src/main/java/org/jboss/narayana/jta/quickstarts/util/Util.java
+++ b/ArjunaJTA/recovery/src/main/java/org/jboss/narayana/jta/quickstarts/util/Util.java
@@ -44,7 +44,7 @@ public class Util {
 
             for (File f : contents) {
                 if (f.isDirectory()) {
-                    count += countLogRecords(f, count);
+                    count += countLogRecords(f, 0);
                 } else {
                     count += 1;
                 }


### PR DESCRIPTION
The XaResourceRecovery from ActiveMQ cannot be registered as it doesn't implement the XAResourceRecovery. 

Fix messages produced on wrong XASession (not enlisted in transaction); 
fixed connection  leak in initialiseActiveMQClient(); 
replaced broken ActiveMQXAResourceRecovery  with XAResourceRecoveryHelper via XARecoveryModule; 
swapped resource enlistment order so JMS commits before  DummyXAResource halts (ensures message data survives Runtime.halt())