### PR TITLE
Use sed instead of mvn (which might be missing)

### DIFF
--- a/.github/scripts/quickstart.sh
+++ b/.github/scripts/quickstart.sh
@@ -51,7 +51,7 @@ function int_env {
   export -f timeout_adjust || echo "Function timeout_adjust won't be used in the subshells as it can't be exported"
   NARAYANA_REPO=${NARAYANA_REPO:-jbosstm}
   NARAYANA_BRANCH="${NARAYANA_BRANCH:-main}"
-  QUICKSTART_NARAYANA_VERSION=${QUICKSTART_NARAYANA_VERSION:-$(mvn -q help:evaluate -Dexpression=project.version -DforceStdout)}
+  QUICKSTART_NARAYANA_VERSION=${QUICKSTART_NARAYANA_VERSION:-$(sed -n '/<artifactId>narayana-quickstarts-all<\/artifactId>/{n;s/.*<version>\(.*\)<\/version>.*/\1/p}' pom.xml)}
   REDUCE_SPACE=${REDUCE_SPACE:-0}
   NARAYANA_CURRENT_VERSION=${NARAYANA_CURRENT_VERSION:-$QUICKSTART_NARAYANA_VERSION}
 


### PR DESCRIPTION
Fixing the quickstart failure: https://github.com/jbosstm/quickstart/actions/runs/25676143341

Testing here: https://github.com/marcosgopen/quickstart/actions/runs/25794029922/job/75766585624
